### PR TITLE
対戦履歴グラフの右端の表示修正

### DIFF
--- a/src/use_cases/group_line/ReplyMultiHistoryUseCase.py
+++ b/src/use_cases/group_line/ReplyMultiHistoryUseCase.py
@@ -73,7 +73,7 @@ class ReplyMultiHistoryUseCase:
             reply_service.add_message(range_message)
 
         # 対戦結果の累計を計算
-        from datetime import timedelta
+        from datetime import datetime, timedelta
         total_dict = {line_id: 0 for line_id in active_user_line_ids}
         start_date = matches[0].created_at
         end_date = matches[-1].created_at
@@ -86,6 +86,11 @@ class ReplyMultiHistoryUseCase:
                 if line_id in active_user_line_ids:
                     total_dict[line_id] += score
                     history_dict[line_id][match.created_at] = total_dict[line_id]
+        if to_dt is None:
+            to_dt = datetime.now()
+        for line_id, score in total_dict.items():
+            history_dict[line_id][to_dt] = score
+        
 
         # グラフ描画
         import matplotlib
@@ -103,10 +108,12 @@ class ReplyMultiHistoryUseCase:
                 label=line_id_name_dict[line_id])
             
         plt.grid(which='major', axis='y')
-        plt.xlim([start_date - timedelta(minutes=1), end_date])
+        plt.xlim([start_date - timedelta(minutes=1), end_date + timedelta(seconds=(end_date-start_date).total_seconds() // 300)])
         plt.xticks(rotation=30)
         ax.xaxis.set_major_formatter(mdates.DateFormatter("%m/%d %H時"))
         plt.legend()
+        # plt.gca().spines['right'].set_visible(False)
+        # plt.gca().spines['top'].set_visible(False)
 
         try:
             fig.savefig(f"src/uploads/group_history/{req_line_user_id}.png")

--- a/src/use_cases/personal_line/ReplyHistoryUseCase.py
+++ b/src/use_cases/personal_line/ReplyHistoryUseCase.py
@@ -97,14 +97,18 @@ class ReplyHistoryUseCase:
         )
 
         # グラフ描画
-        # 初回値に0を追加
+        # 初回値に0を追加、最後尾には指定された範囲の最終日または現在時点のスコアを追加
         from datetime import timedelta
+        if to_dt is None:
+            to_dt = datetime.now()
+        history[to_dt] = total
+
         start_date: datetime = min(history.keys())
         end_date: datetime = max(history.keys())
         history[start_date - timedelta(minutes=2)] = 0
         history[start_date - timedelta(minutes=1)] = 0
         history = dict(sorted(history.items()))
-
+        
         x =[]
         y =[]
         for k, v in history.items():
@@ -120,7 +124,7 @@ class ReplyHistoryUseCase:
         plt.step(history.keys(), history.values(), where='mid')
 
         plt.grid(which='major', axis='y')
-        plt.xlim([start_date - timedelta(minutes=2), end_date])
+        plt.xlim([start_date - timedelta(minutes=2), end_date + timedelta(seconds=(end_date-start_date).total_seconds() // 300)])
         plt.xticks(rotation=30)
         # locator = mdates.DayLocator()
         # ax.xaxis.set_major_locator(locator)


### PR DESCRIPTION
対戦履歴グラフ作成時の以下の2点を修正
- データの最後尾に、現在時刻（toが指定されている場合はtoの日時）にその時点のスコアを追加
  - 以前まではその範囲内にある対戦履歴のうち最も古いものが最後尾となっていた
  - 2024/3/1までしか対戦履歴がない時に、to=2024/3/30で指定しても2024/3/1が右端に来るようになっていた
- xlimを若干伸ばした