### PR TITLE
refactor: コードレビュー83件対応 - DB構造変更・品質改善・テスト充実

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install $(grep '^ruff==' requirements.txt)
+          pip install $(grep '^ruff==' requirements-dev.in)
       - name: Run ruff
         run: ruff check .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   flask_test:
     build: .
     container_name: flask_test
-    command: tail -f /dev/null
+    command: sh -c "pip install -q -r requirements-dev.in && tail -f /dev/null"
     volumes:
       - .:/app
     env_file:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,14 +2,13 @@
 -r requirements.in
 
 # テスト
-pytest==6.2.5
-pytest-cov==2.12.1
-pytest-mock==3.11.1
-coverage==7.6.1
-pluggy==1.5.0
+pytest==9.0.2
+pytest-cov==7.0.0
+pytest-mock==3.15.1
+coverage[toml]==7.13.4
 
 # Lint
-ruff==0.11.8
+ruff==0.15.4
 
 # デバッグ
 debugpy==1.8.0

--- a/requirements.in
+++ b/requirements.in
@@ -58,9 +58,3 @@ typing-extensions==4.13.2
 # SSL証明書
 certifi==2024.2.2
 
-ruff==0.15.4
-
-# テスト
-pytest
-pytest-cov
-pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # by the following command:
 #
 #    pip-compile --output-file=requirements.txt requirements.in
+# (dev packages are in requirements-dev.in)
 #
 aenum==3.1.16
     # via line-bot-sdk
@@ -44,8 +45,6 @@ contourpy==1.1.1
     # via
     #   -r requirements.in
     #   matplotlib
-coverage[toml]==7.13.4
-    # via pytest-cov
 cryptography==46.0.0
     # via authlib
 cycler==0.12.1
@@ -117,8 +116,6 @@ idna==3.11
     # via
     #   requests
     #   yarl
-iniconfig==2.3.0
-    # via pytest
 itsdangerous==2.2.0
     # via flask
 japanize-matplotlib==1.1.3
@@ -157,15 +154,10 @@ packaging==26.0
     # via
     #   gunicorn
     #   matplotlib
-    #   pytest
 pillow==10.2.0
     # via
     #   -r requirements.in
     #   matplotlib
-pluggy==1.6.0
-    # via
-    #   pytest
-    #   pytest-cov
 propcache==0.4.1
     # via
     #   aiohttp
@@ -195,8 +187,6 @@ pydantic-core==2.27.2
     # via
     #   -r requirements.in
     #   pydantic
-pygments==2.19.2
-    # via pytest
 pyjwt==2.9.0
     # via
     #   -r requirements.in
@@ -207,15 +197,6 @@ pyparsing==3.1.4
     # via
     #   -r requirements.in
     #   matplotlib
-pytest==9.0.2
-    # via
-    #   -r requirements.in
-    #   pytest-cov
-    #   pytest-mock
-pytest-cov==7.0.0
-    # via -r requirements.in
-pytest-mock==3.15.1
-    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   line-bot-sdk
@@ -229,8 +210,6 @@ requests==2.32.5
     #   line-bot-sdk
 rsa==4.9.1
     # via google-auth
-ruff==0.15.4
-    # via -r requirements.in
 six==1.17.0
     # via python-dateutil
 typing-extensions==4.13.2

--- a/scripts/migrate_group_settings.py
+++ b/scripts/migrate_group_settings.py
@@ -12,7 +12,7 @@
 
 注意:
     - migration 完了後、group_settings コレクションは不要になる
-    - この script は idempotent（何度実行しても安全）
+    - この script は idempotent(何度実行しても安全)
 """
 import os
 import sys

--- a/scripts/migrate_group_settings.py
+++ b/scripts/migrate_group_settings.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""DB-02 マイグレーション: group_settings コレクションを groups に embedded 化
+
+実行手順:
+    cd /path/to/project
+    python scripts/migrate_group_settings.py
+
+内容:
+    - group_settings コレクションの各ドキュメントを取得
+    - 対応する group ドキュメントに settings フィールドとして埋め込む
+    - すでに settings が設定済みのグループはスキップ
+
+注意:
+    - migration 完了後、group_settings コレクションは不要になる
+    - この script は idempotent（何度実行しても安全）
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import dotenv
+
+dotenv.load_dotenv()
+
+from datetime import datetime
+
+from mongo_client import group_settings_collection, groups_collection
+
+
+def migrate():
+    print("DB-02 マイグレーション開始: group_settings → groups.settings")
+
+    all_settings = list(group_settings_collection.find({}))
+    print(f"  group_settings 件数: {len(all_settings)}")
+
+    migrated = 0
+    skipped = 0
+
+    for gs in all_settings:
+        line_group_id = gs.get("line_group_id")
+        if not line_group_id:
+            print(f"  SKIP (line_group_id なし): {gs.get('_id')}")
+            skipped += 1
+            continue
+
+        # 対応する group を検索
+        group = groups_collection.find_one({"line_group_id": line_group_id})
+        if group is None:
+            print(f"  SKIP (group not found): {line_group_id}")
+            skipped += 1
+            continue
+
+        # すでに settings が設定済みならスキップ
+        if group.get("settings") is not None:
+            print(f"  SKIP (already embedded): {line_group_id}")
+            skipped += 1
+            continue
+
+        # settings を埋め込む
+        settings_dict = {
+            "rate": gs.get("rate", 0),
+            "ranking_prize": gs.get("ranking_prize", [20, 10, -10, -20]),
+            "chip_rate": gs.get("chip_rate", 0),
+            "tobi_prize": gs.get("tobi_prize", 10),
+            "num_of_players": gs.get("num_of_players", 4),
+            "rounding_method": gs.get("rounding_method", 2),
+        }
+        groups_collection.update_one(
+            {"line_group_id": line_group_id},
+            {"$set": {"settings": settings_dict, "updated_at": datetime.now()}},
+        )
+        print(f"  MIGRATED: {line_group_id}")
+        migrated += 1
+
+    print(f"\n完了: migrated={migrated}, skipped={skipped}")
+    print("group_settings コレクションは手動で削除してください (migration 確認後)")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/scripts/migrate_sum_scores.py
+++ b/scripts/migrate_sum_scores.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""DB-04 マイグレーション: match.sum_scores を dict 形式から配列形式に変換
+
+実行手順:
+    cd /path/to/project
+    python scripts/migrate_sum_scores.py
+
+内容:
+    - matches コレクションの各ドキュメントを取得
+    - sum_scores が dict 形式のドキュメントを配列形式に変換
+    - すでに配列形式のドキュメントはスキップ
+
+注意:
+    - この script は idempotent（何度実行しても安全）
+    - 変換後は sum_scores: [{"line_user_id": "...", "score": N}, ...] 形式になる
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import dotenv
+
+dotenv.load_dotenv()
+
+from datetime import datetime
+
+from mongo_client import matches_collection
+
+
+def migrate():
+    print("DB-04 マイグレーション開始: match.sum_scores dict → list")
+
+    all_matches = list(matches_collection.find({}))
+    print(f"  matches 件数: {len(all_matches)}")
+
+    migrated = 0
+    skipped = 0
+
+    for match in all_matches:
+        sum_scores = match.get("sum_scores")
+
+        # すでに list 形式ならスキップ
+        if isinstance(sum_scores, list):
+            skipped += 1
+            continue
+
+        # None や空 dict もスキップ（変換不要）
+        if not sum_scores:
+            skipped += 1
+            continue
+
+        # dict → list 変換
+        new_sum_scores = [
+            {"line_user_id": uid, "score": score}
+            for uid, score in sum_scores.items()
+        ]
+        matches_collection.update_one(
+            {"_id": match["_id"]},
+            {"$set": {"sum_scores": new_sum_scores, "updated_at": datetime.now()}},
+        )
+        migrated += 1
+
+    print(f"\n完了: migrated={migrated}, skipped={skipped}")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/scripts/migrate_sum_scores.py
+++ b/scripts/migrate_sum_scores.py
@@ -11,7 +11,7 @@
     - すでに配列形式のドキュメントはスキップ
 
 注意:
-    - この script は idempotent（何度実行しても安全）
+    - この script は idempotent(何度実行しても安全)
     - 変換後は sum_scores: [{"line_user_id": "...", "score": N}, ...] 形式になる
 """
 import os
@@ -45,7 +45,7 @@ def migrate():
             skipped += 1
             continue
 
-        # None や空 dict もスキップ（変換不要）
+        # None や空 dict もスキップ(変換不要)
         if not sum_scores:
             skipped += 1
             continue

--- a/scripts/migrate_user_hanchans.py
+++ b/scripts/migrate_user_hanchans.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""DB-03 マイグレーション: user_hanchans を hanchan.results として embedded 化
+
+実行手順:
+    cd /path/to/project
+    python scripts/migrate_user_hanchans.py
+
+内容:
+    - user_hanchans コレクションの全ドキュメントを取得
+    - 各 user_hanchan を対応する hanchan の results 配列に追加
+    - すでに results が存在する hanchan はスキップ
+
+注意:
+    - この script は idempotent（何度実行しても安全）
+    - 変換後は hanchan.results: [{line_user_id, rank, point, yakuman_count}, ...] 形式になる
+    - マイグレーション完了後、user_hanchans コレクションはアーカイブ or 削除可
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import dotenv
+
+dotenv.load_dotenv()
+
+from collections import defaultdict
+from datetime import datetime
+
+from mongo_client import hanchans_collection, user_hanchans_collection
+
+
+def migrate():
+    print("DB-03 マイグレーション開始: user_hanchans → hanchan.results")
+
+    all_user_hanchans = list(user_hanchans_collection.find({}))
+    print(f"  user_hanchans 件数: {len(all_user_hanchans)}")
+
+    # hanchan_id → list[user_hanchan] のマップを作成
+    hanchan_results_map: dict = defaultdict(list)
+    for uh in all_user_hanchans:
+        hanchan_id = uh.get("hanchan_id")
+        if hanchan_id is None:
+            continue
+        hanchan_results_map[hanchan_id].append({
+            "line_user_id": uh.get("line_user_id"),
+            "rank": uh.get("rank"),
+            "point": uh.get("point"),
+            "yakuman_count": uh.get("yakuman_count", 0),
+        })
+
+    migrated = 0
+    skipped = 0
+
+    for hanchan_id, results in hanchan_results_map.items():
+        hanchan = hanchans_collection.find_one({"_id": hanchan_id})
+        if hanchan is None:
+            print(f"  WARNING: hanchan not found for _id={hanchan_id}, skipping")
+            skipped += 1
+            continue
+
+        # すでに results が存在する場合はスキップ（idempotent）
+        existing_results = hanchan.get("results") or []
+        if existing_results:
+            skipped += 1
+            continue
+
+        hanchans_collection.update_one(
+            {"_id": hanchan_id},
+            {"$set": {"results": results, "updated_at": datetime.now()}},
+        )
+        migrated += 1
+
+    print(f"\n完了: migrated={migrated}, skipped={skipped}")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/scripts/migrate_user_hanchans.py
+++ b/scripts/migrate_user_hanchans.py
@@ -11,7 +11,7 @@
     - すでに results が存在する hanchan はスキップ
 
 注意:
-    - この script は idempotent（何度実行しても安全）
+    - この script は idempotent(何度実行しても安全)
     - 変換後は hanchan.results: [{line_user_id, rank, point, yakuman_count}, ...] 形式になる
     - マイグレーション完了後、user_hanchans コレクションはアーカイブ or 削除可
 """
@@ -59,7 +59,7 @@ def migrate():
             skipped += 1
             continue
 
-        # すでに results が存在する場合はスキップ（idempotent）
+        # すでに results が存在する場合はスキップ(idempotent)
         existing_results = hanchan.get("results") or []
         if existing_results:
             skipped += 1

--- a/src/apis/auth.py
+++ b/src/apis/auth.py
@@ -1,6 +1,7 @@
 # Auth
 from flask import (
     Blueprint,
+    abort,
     jsonify,
     make_response,
     redirect,
@@ -21,6 +22,9 @@ auth_blueprint = Blueprint("auth_blueprint", __name__, url_prefix="/auth")
 
 @auth_blueprint.route("/login", methods=["POST"])
 def api_login():
+    # 本番環境ではパスワード認証なし /auth/login を無効化（Google OAuth のみ使用）
+    if env_var.FLASK_ENV == "production":
+        abort(404)
     body = request.get_json(silent=True) or {}
     user_id = body.get("user_id")
     if not user_id:

--- a/src/apis/config.py
+++ b/src/apis/config.py
@@ -23,8 +23,8 @@ config_blueprint = Blueprint(
 @config_blueprint.route("/")
 def get_configs():
     data = GetConfigsForWebUseCase().execute()
-    keys = ["_id", "key", "value", "target_id"]
-    input_keys = ["key", "value", "target_id"]
+    keys = ["_id", "rate", "ranking_prize", "chip_rate", "tobi_prize", "num_of_players", "rounding_method"]
+    input_keys = ["rate", "ranking_prize", "chip_rate", "tobi_prize", "num_of_players", "rounding_method"]
     return render_template(
         "model.html",
         title="configs",
@@ -40,7 +40,7 @@ def configs_detail(_id):
     data = GetConfigForWebUseCase().execute(_id)
     if data is None:
         raise NotFoundErr()
-    input_keys = ["_id", "key", "value", "target_id"]
+    input_keys = ["line_group_id", "rate", "ranking_prize", "chip_rate", "tobi_prize", "num_of_players", "rounding_method"]
     return render_template(
         "detail.html",
         title="configs",
@@ -64,5 +64,5 @@ def update_config():
 @config_blueprint.route("/delete", methods=["POST"])
 def delete_configs():
     target_id = request.args.get("target_id")
-    DeleteConfigsForWebUseCase().execute([int(target_id)])
+    DeleteConfigsForWebUseCase().execute([target_id])
     return redirect(url_for("config_blueprint.get_configs"))

--- a/src/application_service/__init__.py
+++ b/src/application_service/__init__.py
@@ -4,6 +4,7 @@ from .graph_service import GraphService
 from .message_service import MessageService
 
 # from .OcrService import OcrService
+from .ranking_table_image_builder import RankingTableImageBuilder
 from .reply_service import ReplyService
 from .request_info_service import RequestInfoService
 from .rich_menu_service import RichMenuService
@@ -15,3 +16,4 @@ graph_service = GraphService()
 reply_service = ReplyService()
 rich_menu_service = RichMenuService()
 calculate_service = CalculateService()
+ranking_table_image_builder = RankingTableImageBuilder()

--- a/src/application_service/message_service.py
+++ b/src/application_service/message_service.py
@@ -210,7 +210,7 @@ class MessageService(IMessageService):
     def parse_date_range_from_params(
         self, params: dict,
     ) -> Tuple[Optional[datetime], Optional[datetime], bool]:
-        """params から "from"/"to" キーを読み取り日付を解析する。
+        """Params から "from"/"to" キーを読み取り日付を解析する。
 
         戻り値: (from_dt, to_dt, is_valid)
         is_valid=False の場合、from_dt/to_dt は None。

--- a/src/application_service/message_service.py
+++ b/src/application_service/message_service.py
@@ -1,7 +1,7 @@
 import random
 import re
 from datetime import datetime
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from domain_model.entities.match import Match
 from domain_service import (
@@ -9,6 +9,11 @@ from domain_service import (
 )
 
 from .interfaces.i_message_service import IMessageService
+
+DATE_FORMAT_ERROR_MESSAGES = (
+    "日付は以下のフォーマットで入力してください。",
+    "[日付の入力方法]\n\nYYYY年MM月DD日\n→ YYYYMMDD\n\n20YY年MM月DD日\n→ YYMMDD\n\n今年MM月DD日\n→ MMDD\n\n今月DD日\n→ DD",
+)
 
 KANSUJI = ["一", "二", "三", "四", "五", "六", "七", "八", "九"]
 HAI = (
@@ -83,6 +88,8 @@ finish_hanchan_messages = [
 
 
 class MessageService(IMessageService):
+    DATE_FORMAT_ERROR_MESSAGES = DATE_FORMAT_ERROR_MESSAGES
+
     def get_random_hai(
         self,
         line_user_id: str,
@@ -199,6 +206,20 @@ class MessageService(IMessageService):
                 return (None, True)
 
         return (result, False)
+
+    def parse_date_range_from_params(
+        self, params: dict,
+    ) -> Tuple[Optional[datetime], Optional[datetime], bool]:
+        """params から "from"/"to" キーを読み取り日付を解析する。
+
+        戻り値: (from_dt, to_dt, is_valid)
+        is_valid=False の場合、from_dt/to_dt は None。
+        """
+        from_str = params.get("from")
+        to_str = params.get("to")
+        from_dt, from_is_invalid = self.parse_date_from_text(from_str)
+        to_dt, to_is_invalid = self.parse_date_from_text(to_str)
+        return from_dt, to_dt, not (from_is_invalid or to_is_invalid)
 
     def create_range_message(self, from_dt: datetime, to_dt: datetime) -> str:
         range_message = ""

--- a/src/application_service/ranking_table_image_builder.py
+++ b/src/application_service/ranking_table_image_builder.py
@@ -1,0 +1,229 @@
+import io
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
+import env_var
+from PIL import Image, ImageDraw, ImageFont
+
+logger = logging.getLogger(__name__)
+
+
+class RankingTableImageBuilder:
+    SCALE = 1
+    BG_COLOR = (33, 33, 33, 255)
+    FONT_COLOR = (255, 255, 255)
+    WIDTH = 1024
+    DUMMY_MIN_SCORE = -10000
+
+    def _create_base_image(self, num_users: int) -> Image.Image:
+        scale = self.SCALE
+        width = self.WIDTH * scale
+        height = (768 + 110 * max(0, num_users - 6)) * scale
+        base_image = Image.new("RGBA", (width, height), self.BG_COLOR)
+
+        crowns_image = Image.new("RGBA", base_image.size, (255, 255, 255, 0))
+        gold = Image.open("src/static/images/ranking_table/crown_gold.png")
+        silver = Image.open("src/static/images/ranking_table/crown_silver.png")
+        bronze = Image.open("src/static/images/ranking_table/crown_bronze.png")
+        crowns = [(gold, 7, 77), (silver, 13, 190), (bronze, 7, 300)]
+        for i in range(min(3, num_users)):
+            crowns_image.paste(
+                crowns[i][0], (crowns[i][1] * scale, crowns[i][2] * scale),
+            )
+        return Image.alpha_composite(base_image, crowns_image)
+
+    def _paste_profile_images(self, base: Image.Image, sorted_ids: list) -> None:
+        scale = self.SCALE
+        for i, line_id in enumerate(sorted_ids):
+            profile_image = Image.open(f"src/uploads/profile_image/{line_id}.jpeg")
+            profile_image = profile_image.resize((50 * scale, 50 * scale))
+            mask = Image.new("L", profile_image.size, 0)
+            draw_mask = ImageDraw.Draw(mask)
+            draw_mask.ellipse(
+                (0, 0, profile_image.size[0], profile_image.size[1]), fill=255,
+            )
+            h = (90 + 110 * i) * scale
+            base.paste(profile_image, (110 * scale, h), mask)
+
+    def _save_image(self, image: Image.Image, upload_file_path: str) -> Tuple[str, str]:
+        """PIL Image を GCS またはローカルに保存し (url, err) を返す"""
+        buf = io.BytesIO()
+        image.save(buf, format="PNG", quality=75)
+        buf.seek(0)
+        if env_var.GCS_BUCKET_NAME:
+            return self._upload_to_gcs(buf, upload_file_path)
+        return self._save_locally(buf, upload_file_path)
+
+    def _upload_to_gcs(self, buf: io.BytesIO, upload_file_path: str) -> Tuple[str, str]:
+        try:
+            from google.cloud import storage  # noqa: PLC0415
+            blob_name = f"uploads{upload_file_path}"
+            client = storage.Client()
+            bucket = client.bucket(env_var.GCS_BUCKET_NAME)
+            blob = bucket.blob(blob_name)
+            blob.upload_from_file(buf, content_type="image/png")
+            blob.make_public()
+            return (blob.public_url, None)
+        except Exception as err:
+            logger.exception("GCS へのアップロードに失敗しました")
+            return (None, f"ランキング表の画像アップロードに失敗しました: {err}")
+
+    def _save_locally(self, buf: io.BytesIO, upload_file_path: str) -> Tuple[str, str]:
+        try:
+            local_path = f"src/uploads{upload_file_path}"
+            Path(os.path.dirname(local_path)).mkdir(parents=True, exist_ok=True)
+            with open(local_path, "wb") as f:
+                f.write(buf.read())
+            return (f"{env_var.SERVER_URL}/uploads{upload_file_path}", None)
+        except Exception as err:
+            logger.exception("ローカルへの画像保存に失敗しました")
+            return (None, f"ランキング表の画像アップロードに失敗しました: {err}")
+
+    def build_score_table(
+        self,
+        sorted_total_dict: list,
+        display_name_dict: dict,
+        point_dict: dict,
+        max_score_dict: dict,
+        req_line_user_id: str,
+    ) -> str:
+        scale = self.SCALE
+        width = self.WIDTH * scale
+        font_color = self.FONT_COLOR
+
+        base_image = self._create_base_image(len(sorted_total_dict))
+        self._paste_profile_images(base_image, [r[0] for r in sorted_total_dict])
+
+        draw = ImageDraw.Draw(base_image)
+        font_path = env_var.FONT_FILE_PATH
+
+        col_font = ImageFont.truetype(font_path, 20 * scale)
+        h = 50 * scale
+        for text, w in [
+            ("累計得点", 450),
+            ("参加半荘数", 600),
+            ("最高得点", 775),
+            ("平均素点", 950),
+        ]:
+            x, y, _x2, _y2 = draw.textbbox((w * scale, h), text, font=col_font, anchor="mm")
+            draw.text((x, y), text, font_color, font=col_font, align="center")
+
+        draw.line((0, 65 * scale, width, 65 * scale), fill=(255, 255, 255), width=2)
+
+        font = ImageFont.truetype(font_path, 30 * scale)
+        for i, r in enumerate(sorted_total_dict):
+            line_id = r[0]
+            h = (120 + 110 * i) * scale
+
+            text = str(i + 1)
+            x, y, _x2, _y2 = draw.textbbox((50 * scale, h), text, font=font, anchor="mm")
+            draw.text((x, y), text, font_color, font=font, stroke_width=1, align="center")
+
+            text = display_name_dict[line_id]
+            x, y, _x2, _y2 = draw.textbbox((190 * scale, h), text, font=font, anchor="lm")
+            draw.text((x, y), text, font_color, font=font, align="left")
+
+            text = ("+" + str(r[1])) if r[1] > 0 else str(r[1])
+            x, y, _x2, _y2 = draw.textbbox((450 * scale, h), text, font=font, anchor="mm")
+            draw.text((x, y), text, font_color, font=font, align="center")
+
+            text = str(len(point_dict[line_id]))
+            x, y, _x2, _y2 = draw.textbbox((600 * scale, h), text, font=font, anchor="mm")
+            draw.text((x, y), text, font_color, font=font, align="center")
+
+            if max_score_dict[line_id] == self.DUMMY_MIN_SCORE:
+                text = "-"
+            else:
+                m = max_score_dict[line_id]
+                text = ("+" + str(m)) if m > 0 else str(m)
+            x, y, _x2, _y2 = draw.textbbox((775 * scale, h), text, font=font, anchor="mm")
+            draw.text((x, y), text, font_color, font=font, align="center")
+
+            if len(point_dict[line_id]) == 0:
+                text = "-"
+            else:
+                text = str(int(sum(point_dict[line_id]) / len(point_dict[line_id])))
+            x, y, _x2, _y2 = draw.textbbox((950 * scale, h), text, font=font, anchor="mm")
+            draw.text((x, y), text, font_color, font=font, align="center")
+
+            draw.line(
+                (0, (175 + 110 * i) * scale, width, (175 + 110 * i) * scale),
+                fill=(255, 255, 255),
+                width=1,
+            )
+
+        path = f"/ranking_table/{req_line_user_id}_{datetime.now().strftime('%Y%m%d%H%M%S')}.png"
+        url, err = self._save_image(base_image, path)
+        if err:
+            raise FileNotFoundError(err)
+        return url
+
+    def build_rank_table(
+        self,
+        sorted_ave_rank_dict: list,
+        display_name_dict: dict,
+        ave_rank_str_dict: dict,
+        rank_dict: dict,
+        req_line_user_id: str,
+    ) -> str:
+        scale = self.SCALE
+        width = self.WIDTH * scale
+        font_color = self.FONT_COLOR
+
+        base_image = self._create_base_image(len(sorted_ave_rank_dict))
+        self._paste_profile_images(base_image, [r[0] for r in sorted_ave_rank_dict])
+
+        draw = ImageDraw.Draw(base_image)
+        font_path = env_var.FONT_FILE_PATH
+
+        col_font = ImageFont.truetype(font_path, 20 * scale)
+        h = 50 * scale
+        for text, w in [
+            ("平均順位", 450),
+            ("1位", 550),
+            ("2位", 650),
+            ("3位", 750),
+            ("4位", 850),
+            ("飛び", 950),
+        ]:
+            x, y, _x2, _y2 = draw.textbbox((w * scale, h), text, font=col_font, anchor="mm")
+            draw.text((x, y), text, font_color, font=col_font, align="center")
+
+        draw.line((0, 65 * scale, width, 65 * scale), fill=(255, 255, 255), width=2)
+
+        font = ImageFont.truetype(font_path, 30 * scale)
+        for i, r in enumerate(sorted_ave_rank_dict):
+            line_id = r[0]
+            h = (120 + 110 * i) * scale
+
+            text = str(i + 1)
+            x, y, _x2, _y2 = draw.textbbox((50 * scale, h), text, font=font, anchor="mm")
+            draw.text((x, y), text, font_color, font=font, stroke_width=1, align="center")
+
+            text = display_name_dict[line_id]
+            x, y, _x2, _y2 = draw.textbbox((190 * scale, h), text, font=font, anchor="lm")
+            draw.text((x, y), text, font_color, font=font, align="left")
+
+            text = ave_rank_str_dict[line_id]
+            x, y, _x2, _y2 = draw.textbbox((450 * scale, h), text, font=font, anchor="mm")
+            draw.text((x, y), text, font_color, font=font, align="center")
+
+            for rank, w in [(1, 550), (2, 650), (3, 750), (4, 850), (0, 950)]:
+                text = str(rank_dict[line_id][rank])
+                x, y, _x2, _y2 = draw.textbbox((w * scale, h), text, font=font, anchor="mm")
+                draw.text((x, y), text, font_color, font=font, align="center")
+
+            draw.line(
+                (0, (175 + 110 * i) * scale, width, (175 + 110 * i) * scale),
+                fill=(255, 255, 255),
+                width=1,
+            )
+
+        path = f"/ranking_table_rank/{req_line_user_id}_{datetime.now().strftime('%Y%m%d%H%M%S')}.png"
+        url, err = self._save_image(base_image, path)
+        if err:
+            raise FileNotFoundError(err)
+        return url

--- a/src/application_service/ranking_table_image_builder.py
+++ b/src/application_service/ranking_table_image_builder.py
@@ -5,8 +5,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Tuple
 
-import env_var
 from PIL import Image, ImageDraw, ImageFont
+
+import env_var
 
 logger = logging.getLogger(__name__)
 

--- a/src/application_service/reply_service.py
+++ b/src/application_service/reply_service.py
@@ -447,7 +447,26 @@ class ReplyService(IReplyService):
                 )
             except ApiException as err:
                 logger.warning("リプライに失敗しました: %s", err)
-                # reply_token は一度使用済みのため push_message でエラー通知する
+                # reply_token 期限切れ等の場合は push_message でフォールバック送信
+                push_to = None
+                if hasattr(event, "source"):
+                    source = event.source
+                    if hasattr(source, "group_id") and source.group_id:
+                        push_to = source.group_id
+                    elif hasattr(source, "user_id") and source.user_id:
+                        push_to = source.user_id
+                if push_to:
+                    try:
+                        text_contents = [m for m in contents if isinstance(m, TextMessage)]
+                        if text_contents:
+                            line_bot_api.push_message(
+                                PushMessageRequest(
+                                    to=push_to,
+                                    messages=text_contents,
+                                ),
+                            )
+                    except ApiException:
+                        logger.exception("フォールバック push も失敗しました")
                 self.push_a_message(
                     to=env_var.SERVER_ADMIN_LINE_USER_ID,
                     message=str(err),

--- a/src/domain_model/entities/group.py
+++ b/src/domain_model/entities/group.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 from bson.objectid import ObjectId
+
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 
 
 class GroupMode(Enum):
@@ -17,6 +20,7 @@ class Group:
     line_group_id: str
     mode: str = GroupMode.wait.value
     active_match_id: ObjectId = field(default=None)
+    settings: Optional[EmbeddedGroupSettings] = field(default=None)
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
     _id: ObjectId = field(default=None)

--- a/src/domain_model/entities/group_setting.py
+++ b/src/domain_model/entities/group_setting.py
@@ -15,11 +15,11 @@ from domain_model.constants import (
 
 __all__ = [
     "CHIP_RATE_LIST",
-    "EmbeddedGroupSettings",
     "NUM_OF_PLAYERS_LIST",
     "RANKING_PRIZE_LIST",
     "RATE_LIST",
     "ROUNDING_METHOD_LIST",
+    "EmbeddedGroupSettings",
     "GroupSetting",
     "RoundingMethod",
 ]
@@ -27,7 +27,8 @@ __all__ = [
 
 @dataclass
 class EmbeddedGroupSettings:
-    """Group に embedded される設定（_id・line_group_id なし）"""
+    """Group に embedded される設定(_id・line_group_id なし)"""
+
     rate: int = 0
     ranking_prize: List[int] = field(default=None)
     chip_rate: int = 0
@@ -63,7 +64,8 @@ class EmbeddedGroupSettings:
 
 @dataclass
 class GroupSetting:
-    """後方互換のため残す（migration 後に削除予定）"""
+    """後方互換のため残す(migration 後に削除予定)"""
+
     line_group_id: str
     rate: int = 0
     ranking_prize: List[int] = field(default=None)

--- a/src/domain_model/entities/group_setting.py
+++ b/src/domain_model/entities/group_setting.py
@@ -15,6 +15,7 @@ from domain_model.constants import (
 
 __all__ = [
     "CHIP_RATE_LIST",
+    "EmbeddedGroupSettings",
     "NUM_OF_PLAYERS_LIST",
     "RANKING_PRIZE_LIST",
     "RATE_LIST",
@@ -25,7 +26,44 @@ __all__ = [
 
 
 @dataclass
+class EmbeddedGroupSettings:
+    """Group に embedded される設定（_id・line_group_id なし）"""
+    rate: int = 0
+    ranking_prize: List[int] = field(default=None)
+    chip_rate: int = 0
+    tobi_prize: int = 10
+    num_of_players: int = 4
+    rounding_method: int = RoundingMethod.go_san_roku
+
+    def __post_init__(self):  # noqa: D105
+        if self.ranking_prize is None:
+            self.ranking_prize = [20, 10, -10, -20]
+
+    def to_dict(self) -> dict:
+        return {
+            "rate": self.rate,
+            "ranking_prize": self.ranking_prize,
+            "chip_rate": self.chip_rate,
+            "tobi_prize": self.tobi_prize,
+            "num_of_players": self.num_of_players,
+            "rounding_method": self.rounding_method,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "EmbeddedGroupSettings":
+        return cls(
+            rate=d.get("rate", 0),
+            ranking_prize=d.get("ranking_prize"),
+            chip_rate=d.get("chip_rate", 0),
+            tobi_prize=d.get("tobi_prize", 10),
+            num_of_players=d.get("num_of_players", 4),
+            rounding_method=d.get("rounding_method", RoundingMethod.go_san_roku),
+        )
+
+
+@dataclass
 class GroupSetting:
+    """後方互換のため残す（migration 後に削除予定）"""
     line_group_id: str
     rate: int = 0
     ranking_prize: List[int] = field(default=None)

--- a/src/domain_model/entities/hanchan.py
+++ b/src/domain_model/entities/hanchan.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from bson.objectid import ObjectId
+
+if TYPE_CHECKING:
+    from domain_model.entities.user_hanchan import UserHanchanResult
 
 
 @dataclass
@@ -12,6 +15,7 @@ class Hanchan:
     is_deleted: bool = False
     raw_scores: Dict[str, int] = field(default_factory=dict)
     converted_scores: Dict[str, int] = field(default_factory=dict)
+    results: List["UserHanchanResult"] = field(default_factory=list)
     original_id: Optional[int] = None
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
@@ -22,6 +26,8 @@ class Hanchan:
             self.raw_scores = {}
         if self.converted_scores is None:
             self.converted_scores = {}
+        if self.results is None:
+            self.results = []
         if self.created_at is None:
             self.created_at = datetime.now()
         if self.updated_at is None:

--- a/src/domain_model/entities/user_hanchan.py
+++ b/src/domain_model/entities/user_hanchan.py
@@ -5,6 +5,33 @@ from bson.objectid import ObjectId
 
 
 @dataclass
+class UserHanchanResult:
+    """Hanchan に embedded される結果（_id・hanchan_id なし）"""
+
+    line_user_id: str
+    rank: int
+    point: int
+    yakuman_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "line_user_id": self.line_user_id,
+            "rank": self.rank,
+            "point": self.point,
+            "yakuman_count": self.yakuman_count,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "UserHanchanResult":
+        return cls(
+            line_user_id=d["line_user_id"],
+            rank=d["rank"],
+            point=d["point"],
+            yakuman_count=d.get("yakuman_count", 0),
+        )
+
+
+@dataclass
 class UserHanchan:
     line_user_id: str
     hanchan_id: ObjectId

--- a/src/domain_model/entities/user_hanchan.py
+++ b/src/domain_model/entities/user_hanchan.py
@@ -6,7 +6,7 @@ from bson.objectid import ObjectId
 
 @dataclass
 class UserHanchanResult:
-    """Hanchan に embedded される結果（_id・hanchan_id なし）"""
+    """Hanchan に embedded される結果(_id・hanchan_id なし)"""
 
     line_user_id: str
     rank: int

--- a/src/domain_service/group_service.py
+++ b/src/domain_service/group_service.py
@@ -3,6 +3,7 @@ import logging
 from typing import Optional
 
 from domain_model.entities.group import Group, GroupMode
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 from repositories import group_repository
 
 from .interfaces.i_group_service import IGroupService
@@ -56,10 +57,29 @@ class GroupService(IGroupService):
     def update(self, target: Group) -> None:
         # UC-11: use copy to avoid mutating entity.__dict__ during dict comprehension
         entity_dict = copy.copy(target).__dict__
-        group_repository.update(
-            {"_id": target._id},
-            {k: v for k, v in entity_dict.items() if k != "_id"},
-        )
+        values = {k: v for k, v in entity_dict.items() if k != "_id"}
+        # EmbeddedGroupSettings を dict にシリアライズ
+        if "settings" in values and values["settings"] is not None:
+            values["settings"] = values["settings"].to_dict()
+        group_repository.update({"_id": target._id}, values)
+
+    def get_settings_or_create(self, line_group_id: str) -> EmbeddedGroupSettings:
+        """group.settings を取得し、未設定の場合はデフォルト設定を作成して保存する"""
+        group = self.find_one_by_line_group_id(line_group_id)
+        if group is None:
+            return EmbeddedGroupSettings()
+        if group.settings is not None:
+            return group.settings
+        # settings が未設定（migration 前のデータ）→ デフォルトを作成して保存
+        default_settings = EmbeddedGroupSettings()
+        group_repository.update_settings(line_group_id, default_settings)
+        return default_settings
+
+    def update_settings(self, line_group_id: str, column: str, value) -> None:
+        """group.settings の特定フィールドを更新する"""
+        settings = self.get_settings_or_create(line_group_id)
+        setattr(settings, column, value)
+        group_repository.update_settings(line_group_id, settings)
 
     def delete_by_line_group_id(self, line_group_id: str) -> None:
         group_repository.delete(

--- a/src/domain_service/group_setting_service.py
+++ b/src/domain_service/group_setting_service.py
@@ -1,11 +1,11 @@
-from domain_model.entities.group_setting import GroupSetting
-from repositories import group_setting_repository
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 
 from .interfaces.i_group_setting_service import IGroupSettingService
 
 
 class GroupSettingService(IGroupSettingService):
+    """後方互換のための薄いラッパー。group_service.get_settings_or_create() に委譲する（DB-02 migration 後に削除予定）"""
 
-    def find_or_create(self, line_group_id: str) -> GroupSetting:
-        new_settings = GroupSetting(line_group_id=line_group_id)
-        return group_setting_repository.find_or_create(new_settings)
+    def find_or_create(self, line_group_id: str) -> EmbeddedGroupSettings:
+        from domain_service.group_service import GroupService  # noqa: PLC0415
+        return GroupService().get_settings_or_create(line_group_id)

--- a/src/domain_service/group_setting_service.py
+++ b/src/domain_service/group_setting_service.py
@@ -4,7 +4,7 @@ from .interfaces.i_group_setting_service import IGroupSettingService
 
 
 class GroupSettingService(IGroupSettingService):
-    """後方互換のための薄いラッパー。group_service.get_settings_or_create() に委譲する（DB-02 migration 後に削除予定）"""
+    """後方互換のための薄いラッパー。group_service.get_settings_or_create() に委譲する(DB-02 migration 後に削除予定)"""
 
     def find_or_create(self, line_group_id: str) -> EmbeddedGroupSettings:
         from domain_service.group_service import GroupService  # noqa: PLC0415

--- a/src/domain_service/hanchan_service.py
+++ b/src/domain_service/hanchan_service.py
@@ -90,7 +90,7 @@ class HanchanService(IHanchanService):
         )
 
     def set_results(self, hanchan_id: ObjectId, results: List[UserHanchanResult]) -> None:
-        """半荘の results（embedded UserHanchanResult リスト）を保存する"""
+        """半荘の results(embedded UserHanchanResult リスト)を保存する"""
         hanchan_repository.update(
             {"_id": hanchan_id},
             {"results": results},

--- a/src/domain_service/hanchan_service.py
+++ b/src/domain_service/hanchan_service.py
@@ -6,6 +6,7 @@ from bson.objectid import ObjectId
 from pymongo import ASCENDING
 
 from domain_model.entities.hanchan import Hanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
 from repositories import hanchan_repository
 
 from .interfaces.i_hanchan_service import IHanchanService
@@ -81,14 +82,22 @@ class HanchanService(IHanchanService):
 
     def update(self, target: Hanchan) -> None:
         # UC-11: use copy to avoid mutating entity.__dict__ during dict comprehension
+        # Exclude "results" — use set_results() to update embedded results separately
         entity_dict = copy.copy(target).__dict__
         hanchan_repository.update(
             {"_id": target._id},
-            {k: v for k, v in entity_dict.items() if k != "_id"},
+            {k: v for k, v in entity_dict.items() if k not in ("_id", "results")},
+        )
+
+    def set_results(self, hanchan_id: ObjectId, results: List[UserHanchanResult]) -> None:
+        """半荘の results（embedded UserHanchanResult リスト）を保存する"""
+        hanchan_repository.update(
+            {"_id": hanchan_id},
+            {"results": results},
         )
 
     def disable_by_match_id(self, match_id: ObjectId) -> None:
-        hanchan_repository.update(
+        hanchan_repository.update_many(
             {"match_id": match_id},
             {"is_deleted": True},
         )

--- a/src/domain_service/interfaces/i_hanchan_service.py
+++ b/src/domain_service/interfaces/i_hanchan_service.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from bson.objectid import ObjectId
 
 from domain_model.entities.hanchan import Hanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
 
 
 class IHanchanService(metaclass=ABCMeta):
@@ -35,6 +36,10 @@ class IHanchanService(metaclass=ABCMeta):
 
     @abstractmethod
     def update(self, target: Hanchan) -> None:
+        pass
+
+    @abstractmethod
+    def set_results(self, hanchan_id: ObjectId, results: List[UserHanchanResult]) -> None:
         pass
 
     @abstractmethod

--- a/src/domain_service/user_hanchan_service.py
+++ b/src/domain_service/user_hanchan_service.py
@@ -1,4 +1,4 @@
-"""user"""
+"""user_hanchan_service: hanchan.results に embedded された結果を UserHanchan として返す"""
 
 from datetime import datetime
 from typing import List
@@ -7,7 +7,7 @@ from bson.objectid import ObjectId
 from pymongo import ASCENDING
 
 from domain_model.entities.user_hanchan import UserHanchan
-from repositories import user_hanchan_repository
+from repositories import hanchan_repository
 
 from .interfaces.i_user_hanchan_service import IUserHanchanService
 
@@ -20,15 +20,31 @@ class UserHanchanService(IUserHanchanService):
         from_dt: datetime = None,
         to_dt: datetime = None,
     ) -> List[UserHanchan]:
-        query_list = [{"line_user_id": {"$in": line_user_ids}}]
+        query_list = [
+            {"results": {"$elemMatch": {"line_user_id": {"$in": line_user_ids}}}},
+        ]
         if from_dt is not None:
             query_list.append({"created_at": {"$gte": from_dt}})
         if to_dt is not None:
             query_list.append({"created_at": {"$lte": to_dt}})
-        return user_hanchan_repository.find(
+        hanchans = hanchan_repository.find(
             query={"$and": query_list},
-            sort=[("hanchan_id", ASCENDING)],
+            sort=[("_id", ASCENDING)],
         )
+        line_user_ids_set = set(line_user_ids)
+        result = []
+        for h in hanchans:
+            for r in h.results:
+                if r.line_user_id in line_user_ids_set:
+                    result.append(UserHanchan(
+                        line_user_id=r.line_user_id,
+                        hanchan_id=h._id,
+                        point=r.point,
+                        rank=r.rank,
+                        yakuman_count=r.yakuman_count,
+                        created_at=h.created_at,
+                    ))
+        return result
 
     def find_all_with_line_user_ids_and_hanchan_ids(
         self,
@@ -38,14 +54,28 @@ class UserHanchanService(IUserHanchanService):
         to_dt: datetime = None,
     ) -> List[UserHanchan]:
         query_list = [{
-            "hanchan_id": {"$in": hanchan_ids},
-            "line_user_id": {"$in": line_user_ids},
+            "_id": {"$in": hanchan_ids},
+            "results": {"$elemMatch": {"line_user_id": {"$in": line_user_ids}}},
         }]
         if from_dt is not None:
             query_list.append({"created_at": {"$gte": from_dt}})
         if to_dt is not None:
             query_list.append({"created_at": {"$lte": to_dt}})
-        return user_hanchan_repository.find(
+        hanchans = hanchan_repository.find(
             query={"$and": query_list},
-            sort=[("hanchan_id", ASCENDING)],
+            sort=[("_id", ASCENDING)],
         )
+        line_user_ids_set = set(line_user_ids)
+        result = []
+        for h in hanchans:
+            for r in h.results:
+                if r.line_user_id in line_user_ids_set:
+                    result.append(UserHanchan(
+                        line_user_id=r.line_user_id,
+                        hanchan_id=h._id,
+                        point=r.point,
+                        rank=r.rank,
+                        yakuman_count=r.yakuman_count,
+                        created_at=h.created_at,
+                    ))
+        return result

--- a/src/repositories/group_repository.py
+++ b/src/repositories/group_repository.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple
 from pymongo import ASCENDING, ReturnDocument
 
 from domain_model.entities.group import Group
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 from domain_model.i_repositories.i_group_repository import IGroupRepository
 from mongo_client import groups_collection
 
@@ -66,11 +67,20 @@ class GroupRepository(IGroupRepository):
         result = groups_collection.delete_many(filter=query)
         return result.deleted_count
 
+    def update_settings(self, line_group_id: str, settings: EmbeddedGroupSettings) -> int:
+        return self.update(
+            query={"line_group_id": line_group_id},
+            new_values={"settings": settings.to_dict()},
+        )
+
     def _mapping_record_to_domain(self, record: Dict[str, any]) -> Group:
+        raw_settings = record.get("settings")
+        settings = EmbeddedGroupSettings.from_dict(raw_settings) if raw_settings else None
         return Group(
             line_group_id=record.get("line_group_id"),
             mode=record.get("mode"),
             active_match_id=record.get("active_match_id"),
+            settings=settings,
             created_at=record.get("created_at"),
             updated_at=record.get("updated_at"),
             _id=record.get("_id"),

--- a/src/repositories/hanchan_repository.py
+++ b/src/repositories/hanchan_repository.py
@@ -5,8 +5,16 @@ from typing import Dict, List, Tuple
 from pymongo import ASCENDING
 
 from domain_model.entities.hanchan import Hanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
 from domain_model.i_repositories.i_hanchan_repository import IHanchanRepository
 from mongo_client import hanchans_collection
+
+
+def _results_to_list(results) -> list:
+    """UserHanchanResult リスト → MongoDB 用 dict リストに変換"""
+    if not results:
+        return []
+    return [r.to_dict() if hasattr(r, "to_dict") else r for r in results]
 
 
 class HanchanRepository(IHanchanRepository):
@@ -18,6 +26,7 @@ class HanchanRepository(IHanchanRepository):
         new_dict = copy.deepcopy(new_record.__dict__)
         if new_record._id is None:
             new_dict.pop("_id")
+        new_dict["results"] = _results_to_list(new_dict.get("results", []))
         result = hanchans_collection.insert_one(new_dict)
         new_record._id = result.inserted_id
         return new_record
@@ -27,6 +36,19 @@ class HanchanRepository(IHanchanRepository):
         query: Dict[str, any],
         new_values: Dict[str, any],
     ) -> int:
+        filter_query = {**query, "is_deleted": {"$ne": True}}
+        new_values["updated_at"] = datetime.now()
+        if "results" in new_values:
+            new_values["results"] = _results_to_list(new_values["results"])
+        result = hanchans_collection.update_one(filter_query, {"$set": new_values})
+        return result.matched_count
+
+    def update_many(
+        self,
+        query: Dict[str, any],
+        new_values: Dict[str, any],
+    ) -> int:
+        """複数ドキュメントを一括更新する（bulk archive 等の用途専用）"""
         filter_query = {**query, "is_deleted": {"$ne": True}}
         new_values["updated_at"] = datetime.now()
         result = hanchans_collection.update_many(filter_query, {"$set": new_values})
@@ -55,12 +77,14 @@ class HanchanRepository(IHanchanRepository):
         return result.deleted_count
 
     def _mapping_record_to_domain(self, record: Dict[str, any]) -> Hanchan:
+        raw_results = record.get("results") or []
         return Hanchan(
             line_group_id=record.get("line_group_id"),
             match_id=record.get("match_id"),
             is_deleted=record.get("is_deleted", False),
             raw_scores=record.get("raw_scores"),
             converted_scores=record.get("converted_scores"),
+            results=[UserHanchanResult.from_dict(r) for r in raw_results],
             created_at=record.get("created_at"),
             updated_at=record.get("updated_at"),
             _id=record.get("_id"),

--- a/src/repositories/hanchan_repository.py
+++ b/src/repositories/hanchan_repository.py
@@ -48,7 +48,7 @@ class HanchanRepository(IHanchanRepository):
         query: Dict[str, any],
         new_values: Dict[str, any],
     ) -> int:
-        """複数ドキュメントを一括更新する（bulk archive 等の用途専用）"""
+        """複数ドキュメントを一括更新する(bulk archive 等の用途専用)"""
         filter_query = {**query, "is_deleted": {"$ne": True}}
         new_values["updated_at"] = datetime.now()
         result = hanchans_collection.update_many(filter_query, {"$set": new_values})

--- a/src/repositories/match_repository.py
+++ b/src/repositories/match_repository.py
@@ -17,7 +17,7 @@ def _sum_scores_to_list(scores: Dict[str, int]) -> List[dict]:
 
 
 def _sum_scores_to_dict(scores) -> Dict[str, int]:
-    """MongoDB list 形式 → Python Dict に変換する（後方互換: dict 形式もそのまま受け入れる）"""
+    """MongoDB list 形式 → Python Dict に変換する(後方互換: dict 形式もそのまま受け入れる)"""
     if scores is None:
         return {}
     if isinstance(scores, list):

--- a/src/repositories/match_repository.py
+++ b/src/repositories/match_repository.py
@@ -9,6 +9,23 @@ from domain_model.i_repositories.i_match_repository import IMatchRepository
 from mongo_client import matches_collection
 
 
+def _sum_scores_to_list(scores: Dict[str, int]) -> List[dict]:
+    """Python Dict → MongoDB list 形式に変換する"""
+    if not scores:
+        return []
+    return [{"line_user_id": uid, "score": s} for uid, s in scores.items()]
+
+
+def _sum_scores_to_dict(scores) -> Dict[str, int]:
+    """MongoDB list 形式 → Python Dict に変換する（後方互換: dict 形式もそのまま受け入れる）"""
+    if scores is None:
+        return {}
+    if isinstance(scores, list):
+        return {item["line_user_id"]: item["score"] for item in scores}
+    # 旧 dict 形式
+    return scores
+
+
 class MatchRepository(IMatchRepository):
     def create(
         self,
@@ -17,6 +34,9 @@ class MatchRepository(IMatchRepository):
         new_dict = copy.deepcopy(new_record.__dict__)
         if new_record._id is None:
             new_dict.pop("_id")
+        # sum_scores を list 形式で保存
+        if "sum_scores" in new_dict:
+            new_dict["sum_scores"] = _sum_scores_to_list(new_dict["sum_scores"])
         result = matches_collection.insert_one(new_dict)
         new_record._id = result.inserted_id
         return new_record
@@ -28,6 +48,9 @@ class MatchRepository(IMatchRepository):
     ) -> int:
         filter_query = {**query, "is_deleted": {"$ne": True}}
         new_values["updated_at"] = datetime.now()
+        # sum_scores を list 形式で保存
+        if "sum_scores" in new_values:
+            new_values["sum_scores"] = _sum_scores_to_list(new_values["sum_scores"])
         result = matches_collection.update_one(filter_query, {"$set": new_values})
         return result.matched_count
 
@@ -59,7 +82,7 @@ class MatchRepository(IMatchRepository):
             chip_scores=record.get("chip_scores"),
             chip_prices=record.get("chip_prices"),
             active_hanchan_id=record.get("active_hanchan_id"),
-            sum_scores=record.get("sum_scores"),
+            sum_scores=_sum_scores_to_dict(record.get("sum_scores")),
             sum_prices=record.get("sum_prices"),
             sum_prices_with_chip=record.get("sum_prices_with_chip"),
             _id=record.get("_id"),

--- a/src/use_cases/common_line/reply_rank_histogram_use_case.py
+++ b/src/use_cases/common_line/reply_rank_histogram_use_case.py
@@ -1,6 +1,3 @@
-import matplotlib as mpl
-
-mpl.use("agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 
@@ -19,15 +16,12 @@ from domain_service import (
 class ReplyRankHistogramUseCase:
     def execute(self) -> None:
         req_line_user_id = request_info_service.req_line_user_id
-        from_str = request_info_service.params.get("from")
-        to_str = request_info_service.params.get("to")
-        from_dt, from_is_invalid = message_service.parse_date_from_text(from_str)
-        to_dt, to_is_invalid = message_service.parse_date_from_text(to_str)
-        if from_is_invalid or to_is_invalid:
-            reply_service.add_message("日付は以下のフォーマットで入力してください。")
-            reply_service.add_message(
-                "[日付の入力方法]\n\nYYYY年MM月DD日\n→ YYYYMMDD\n\n20YY年MM月DD日\n→ YYMMDD\n\n今年MM月DD日\n→ MMDD\n\n今月DD日\n→ DD",
-            )
+        from_dt, to_dt, is_valid = message_service.parse_date_range_from_params(
+            request_info_service.params,
+        )
+        if not is_valid:
+            for msg in message_service.DATE_FORMAT_ERROR_MESSAGES:
+                reply_service.add_message(msg)
             return
         user_hanchans = user_hanchan_service.find_all_each_line_user_id(
             line_user_ids=[req_line_user_id],

--- a/src/use_cases/common_line/reply_rank_history_use_case.py
+++ b/src/use_cases/common_line/reply_rank_history_use_case.py
@@ -1,8 +1,5 @@
 from itertools import groupby
 
-import matplotlib as mpl
-
-mpl.use("agg")
 import matplotlib.pyplot as plt
 
 from application_service import (
@@ -21,15 +18,12 @@ from domain_service import (
 class ReplyRankHistoryUseCase:
     def execute(self) -> None:
         req_line_user_id = request_info_service.req_line_user_id
-        from_str = request_info_service.params.get("from")
-        to_str = request_info_service.params.get("to")
-        from_dt, from_is_invalid = message_service.parse_date_from_text(from_str)
-        to_dt, to_is_invalid = message_service.parse_date_from_text(to_str)
-        if from_is_invalid or to_is_invalid:
-            reply_service.add_message("日付は以下のフォーマットで入力してください。")
-            reply_service.add_message(
-                "[日付の入力方法]\n\nYYYY年MM月DD日\n→ YYYYMMDD\n\n20YY年MM月DD日\n→ YYMMDD\n\n今年MM月DD日\n→ MMDD\n\n今月DD日\n→ DD",
-            )
+        from_dt, to_dt, is_valid = message_service.parse_date_range_from_params(
+            request_info_service.params,
+        )
+        if not is_valid:
+            for msg in message_service.DATE_FORMAT_ERROR_MESSAGES:
+                reply_service.add_message(msg)
             return
         user_hanchans = user_hanchan_service.find_all_each_line_user_id(
             line_user_ids=[req_line_user_id],

--- a/src/use_cases/create_dummy_use_case.py
+++ b/src/use_cases/create_dummy_use_case.py
@@ -5,7 +5,6 @@ import sys
 
 from repositories import (
     group_repository,
-    group_setting_repository,
     hanchan_repository,
     match_repository,
     user_repository,
@@ -18,7 +17,6 @@ sys.path.append(
 
 from dummies import (
     generate_dummy_group_list,
-    generate_dummy_group_setting_list,
     generate_dummy_hanchan_list,
     generate_dummy_match_list,
     generate_dummy_user_list,
@@ -31,7 +29,6 @@ class CreateDummyUseCase:
         users = generate_dummy_user_list()[:10]
         web_users = generate_dummy_web_user_list()[:4]
         groups = generate_dummy_group_list()[:5]
-        group_settings = generate_dummy_group_setting_list()[:3]
         hanchans = generate_dummy_hanchan_list()[:7]
         matches = generate_dummy_match_list()[:6]
 
@@ -41,8 +38,6 @@ class CreateDummyUseCase:
             web_user_repository.create(web_user)
         for group in groups:
             group_repository.create(group)
-        for group_setting in group_settings:
-            group_setting_repository.create(group_setting)
         for match in matches:
             match_repository.create(match)
         for hanchan in hanchans:

--- a/src/use_cases/group_line/reply_multi_history_use_case.py
+++ b/src/use_cases/group_line/reply_multi_history_use_case.py
@@ -1,12 +1,9 @@
 from datetime import datetime, timedelta
 from typing import Dict, List
 
-import matplotlib
-matplotlib.use("agg")
-import matplotlib.pyplot as plt
+import japanize_matplotlib  # noqa: F401
 import matplotlib.dates as mdates
-# flake8: noqa
-import japanize_matplotlib
+import matplotlib.pyplot as plt
 
 from application_service import (
     graph_service,
@@ -53,15 +50,12 @@ class ReplyMultiHistoryUseCase:
             )
 
         # 関連する対戦結果の取得
-        from_str = request_info_service.params.get("from")
-        to_str = request_info_service.params.get("to")
-        from_dt, from_is_invalid = message_service.parse_date_from_text(from_str)
-        to_dt, to_is_invalid = message_service.parse_date_from_text(to_str)
-        if from_is_invalid or to_is_invalid:
-            reply_service.add_message("日付は以下のフォーマットで入力してください。")
-            reply_service.add_message(
-                "[日付の入力方法]\n\nYYYY年MM月DD日\n→ YYYYMMDD\n\n20YY年MM月DD日\n→ YYMMDD\n\n今年MM月DD日\n→ MMDD\n\n今月DD日\n→ DD"
-            )
+        from_dt, to_dt, is_valid = message_service.parse_date_range_from_params(
+            request_info_service.params,
+        )
+        if not is_valid:
+            for msg in message_service.DATE_FORMAT_ERROR_MESSAGES:
+                reply_service.add_message(msg)
             return
         umList = user_match_service.find_all_by_user_id_list(
             target_user_ids,

--- a/src/use_cases/group_line/reply_multi_history_use_case.py
+++ b/src/use_cases/group_line/reply_multi_history_use_case.py
@@ -7,21 +7,21 @@ import matplotlib.pyplot as plt
 
 from application_service import (
     graph_service,
+    message_service,
     reply_service,
     request_info_service,
-    message_service,
 )
 from domain_service import (
-    user_service,
     match_service,
     user_match_service,
+    user_service,
 )
+
 
 class ReplyMultiHistoryUseCase:
     def execute(self) -> None:
         req_line_user_id = request_info_service.req_line_user_id
         mention_line_user_ids = request_info_service.mention_line_ids
-        messages = []
         target_user_ids: List[int] = []
         active_user_line_ids: List[str] = []
         line_id_name_dict: Dict[str, str] = {}
@@ -46,7 +46,7 @@ class ReplyMultiHistoryUseCase:
 
         if request_info_service.is_mention_all:
             reply_service.add_message(
-                "@Allによるメンションでは、このグループでの対戦に参加したことのある全ユーザを対象とします。"
+                "@Allによるメンションでは、このグループでの対戦に参加したことのある全ユーザを対象とします。",
             )
 
         # 関連する対戦結果の取得
@@ -57,13 +57,13 @@ class ReplyMultiHistoryUseCase:
             for msg in message_service.DATE_FORMAT_ERROR_MESSAGES:
                 reply_service.add_message(msg)
             return
-        umList = user_match_service.find_all_by_user_id_list(
+        um_list = user_match_service.find_all_by_user_id_list(
             target_user_ids,
             from_dt=from_dt,
             to_dt=to_dt,
         )
         matches = match_service.find_all_for_graph(
-            ids=[um.match_id for um in umList],
+            ids=[um.match_id for um in um_list],
         )
 
         if len(matches) == 0:
@@ -75,7 +75,7 @@ class ReplyMultiHistoryUseCase:
             reply_service.add_message(range_message)
 
         # 対戦結果の累計を計算
-        total_dict = {line_id: 0 for line_id in active_user_line_ids}
+        total_dict = dict.fromkeys(active_user_line_ids, 0)
         start_date = matches[0].created_at
         end_date = matches[-1].created_at
         history_dict = {
@@ -111,7 +111,7 @@ class ReplyMultiHistoryUseCase:
                 start_date - timedelta(minutes=1),
                 end_date
                 + timedelta(seconds=(end_date - start_date).total_seconds() // 100),
-            ]
+            ],
         )
         plt.xticks(rotation=30)
         ax.xaxis.set_major_formatter(mdates.DateFormatter("%m/%d %H時"))

--- a/src/use_cases/group_line/reply_ranking_table_use_case.py
+++ b/src/use_cases/group_line/reply_ranking_table_use_case.py
@@ -1,13 +1,13 @@
-from datetime import datetime
-from typing import Dict, List
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
 
 import certifi
 import urllib3
-from PIL import Image, ImageDraw, ImageFont
 
 import env_var
 from application_service import (
     message_service,
+    ranking_table_image_builder,
     reply_service,
     request_info_service,
 )
@@ -21,27 +21,88 @@ from domain_service import (
 from messaging_api_setting import line_bot_api
 
 
+@dataclass
+class _RankingStats:
+    sorted_total_dict: list = field(default_factory=list)
+    point_dict: dict = field(default_factory=dict)
+    max_score_dict: dict = field(default_factory=dict)
+    sorted_ave_rank_dict: list = field(default_factory=list)
+    ave_rank_str_dict: dict = field(default_factory=dict)
+    rank_dict: dict = field(default_factory=dict)
+
+
 class ReplyRankingTableUseCase:
     def execute(self) -> None:
+        # 1. ユーザー解決
+        target_user_ids, active_user_line_ids = self._resolve_users()
+
+        # 2. 日付範囲解析
+        from_dt, to_dt, is_valid = message_service.parse_date_range_from_params(
+            request_info_service.params,
+        )
+        if not is_valid:
+            for msg in message_service.DATE_FORMAT_ERROR_MESSAGES:
+                reply_service.add_message(msg)
+            return
+
+        # 3. DB取得
+        matches, hanchans, user_hanchans = self._fetch_data(
+            target_user_ids, active_user_line_ids, from_dt, to_dt,
+        )
+
+        # 4. 範囲メッセージ
+        range_message = message_service.create_range_message(from_dt, to_dt)
+        if range_message is not None:
+            reply_service.add_message(range_message)
+
+        # 5. プロフィール画像取得
+        display_name_dict = self._fetch_profile_images(active_user_line_ids)
+
+        # 6. データ集計
+        stats = self._aggregate_stats(matches, hanchans, user_hanchans, active_user_line_ids)
+
+        # 7. 累計得点表 画像生成・送信
+        req_line_user_id = request_info_service.req_line_user_id
+        try:
+            url = ranking_table_image_builder.build_score_table(
+                stats.sorted_total_dict,
+                display_name_dict,
+                stats.point_dict,
+                stats.max_score_dict,
+                req_line_user_id,
+            )
+            reply_service.add_image(url)
+        except FileNotFoundError:
+            self._handle_image_save_error()
+            return
+
+        # 8. 順位表 画像生成・送信
+        try:
+            url = ranking_table_image_builder.build_rank_table(
+                stats.sorted_ave_rank_dict,
+                display_name_dict,
+                stats.ave_rank_str_dict,
+                stats.rank_dict,
+                req_line_user_id,
+            )
+            reply_service.add_image(url)
+        except FileNotFoundError:
+            self._handle_image_save_error()
+
+    def _resolve_users(self) -> Tuple[List[int], List[str]]:
         req_line_user_id = request_info_service.req_line_user_id
         mention_line_user_ids = request_info_service.mention_line_ids
-        messages = []
         target_user_ids: List[int] = []
         active_user_line_ids: List[str] = []
-        line_id_name_dict: Dict[str, str] = {}
         contain_not_friend_user = False
 
         mention_line_user_ids.append(req_line_user_id)
 
-        # 表示対象のユーザ情報の取得
         for mention_line_user_id in set(mention_line_user_ids):
             user = user_service.find_one_by_line_user_id(mention_line_user_id)
-
             if user is None:
                 contain_not_friend_user = True
                 continue
-
-            line_id_name_dict[user.line_user_id] = user.line_user_name
             active_user_line_ids.append(user.line_user_id)
             target_user_ids.append(user._id)
 
@@ -53,16 +114,9 @@ class ReplyRankingTableUseCase:
                 "@Allによるメンションでは、このグループでの対戦に参加したことのある全ユーザを対象とします。",
             )
 
-        from_str = request_info_service.params.get("from")
-        to_str = request_info_service.params.get("to")
-        from_dt, from_is_invalid = message_service.parse_date_from_text(from_str)
-        to_dt, to_is_invalid = message_service.parse_date_from_text(to_str)
-        if from_is_invalid or to_is_invalid:
-            reply_service.add_message("日付は以下のフォーマットで入力してください。")
-            reply_service.add_message(
-                "[日付の入力方法]\n\nYYYY年MM月DD日\n→ YYYYMMDD\n\n20YY年MM月DD日\n→ YYMMDD\n\n今年MM月DD日\n→ MMDD\n\n今月DD日\n→ DD",
-            )
-            return
+        return target_user_ids, active_user_line_ids
+
+    def _fetch_data(self, target_user_ids, active_user_line_ids, from_dt, to_dt):
         um_list = user_match_service.find_all_by_user_id_list(
             target_user_ids,
             from_dt=from_dt,
@@ -75,23 +129,18 @@ class ReplyRankingTableUseCase:
         hanchans = hanchan_service.find_all_archived_by_match_ids(
             match_ids=[m._id for m in matches],
         )
-        user_hanchans = (
-            user_hanchan_service.find_all_with_line_user_ids_and_hanchan_ids(
-                line_user_ids=active_user_line_ids,
-                hanchan_ids=[h._id for h in hanchans],
-                from_dt=from_dt,
-                to_dt=to_dt,
-            )
+        user_hanchans = user_hanchan_service.find_all_with_line_user_ids_and_hanchan_ids(
+            line_user_ids=active_user_line_ids,
+            hanchan_ids=[h._id for h in hanchans],
+            from_dt=from_dt,
+            to_dt=to_dt,
         )
+        return matches, hanchans, user_hanchans
 
-        range_message = message_service.create_range_message(from_dt, to_dt)
-        if range_message is not None:
-            reply_service.add_message(range_message)
-
+    def _fetch_profile_images(self, active_user_line_ids: List[str]) -> Dict[str, str]:
         display_name_dict = {}
         for line_id in active_user_line_ids:
             profile = line_bot_api.get_profile(line_id)
-
             request_methods = urllib3.PoolManager(
                 cert_reqs="CERT_REQUIRED", ca_certs=certifi.where(),
             )
@@ -99,10 +148,10 @@ class ReplyRankingTableUseCase:
             f = open(f"src/uploads/profile_image/{line_id}.jpeg", "wb")
             f.write(response.data)
             f.close()
-
             display_name_dict[line_id] = profile.display_name
+        return display_name_dict
 
-        # データ集計
+    def _aggregate_stats(self, matches, hanchans, user_hanchans, active_user_line_ids) -> _RankingStats:
         # 累計スコア
         total_dict = dict.fromkeys(active_user_line_ids, 0)
         for match in matches:
@@ -120,7 +169,7 @@ class ReplyRankingTableUseCase:
             if uh.point < 0:
                 rank_dict[uh.line_user_id][0] += 1
 
-        dummy_min_score = -10000
+        dummy_min_score = ranking_table_image_builder.DUMMY_MIN_SCORE
         max_score_dict = dict.fromkeys(active_user_line_ids, dummy_min_score)
         for h in hanchans:
             for u, c in h.converted_scores.items():
@@ -142,302 +191,32 @@ class ReplyRankingTableUseCase:
                     sum([rank_dict[line_id][i] * i for i in range(1, 5)]) / h_count
                 )
 
-        # 画像生成
-        scale = 1
-        width, height = (
-            1024 * scale,
-            (768 + 110 * max(0, len(active_user_line_ids) - 6)) * scale,
+        sorted_total_dict = sorted(total_dict.items(), key=lambda x: x[1], reverse=True)
+        sorted_ave_rank_dict = sorted(ave_rank_dict.items(), key=lambda x: x[1], reverse=False)
+
+        return _RankingStats(
+            sorted_total_dict=sorted_total_dict,
+            point_dict=point_dict,
+            max_score_dict=max_score_dict,
+            sorted_ave_rank_dict=sorted_ave_rank_dict,
+            ave_rank_str_dict=ave_rank_str_dict,
+            rank_dict=rank_dict,
         )
-        bg_color = (33, 33, 33, 255)
-        base_image = Image.new("RGBA", (width, height), bg_color)
 
-        # 王冠画像添付
-        crowns_image = Image.new("RGBA", base_image.size, (255, 255, 255, 0))
-        gold = Image.open("src/static/images/ranking_table/crown_gold.png")
-        silver = Image.open("src/static/images/ranking_table/crown_silver.png")
-        bronze = Image.open("src/static/images/ranking_table/crown_bronze.png")
-        crowns = [(gold, 7, 77), (silver, 13, 190), (bronze, 7, 300)]
-        for i in range(min(3, len(active_user_line_ids))):
-            crowns_image.paste(
-                crowns[i][0], (crowns[i][1] * scale, crowns[i][2] * scale),
-            )
-        base_image = Image.alpha_composite(base_image, crowns_image)
-
-        sorted_total_dict = sorted(
-            total_dict.items(),
-            key=lambda x: x[1],
-            reverse=True,
+    def _handle_image_save_error(self) -> None:
+        reply_service.reset()
+        reply_service.add_message(text="システムエラーが発生しました。")
+        messages = [
+            "ランキングの画像アップロードに失敗しました",
+            "送信者: "
+            + (
+                user_service.get_name_by_line_user_id(
+                    request_info_service.req_line_user_id,
+                )
+                or request_info_service.req_line_user_id
+            ),
+        ]
+        reply_service.push_a_message(
+            to=env_var.SERVER_ADMIN_LINE_USER_ID,
+            message="\n".join(messages),
         )
-        for i, r in enumerate(sorted_total_dict):
-            profile_image = Image.open(f"src/uploads/profile_image/{r[0]}.jpeg")
-            profile_image = profile_image.resize((50 * scale, 50 * scale))
-            mask = Image.new("L", profile_image.size, 0)
-            draw_mask = ImageDraw.Draw(mask)
-            draw_mask.ellipse(
-                (0, 0, profile_image.size[0], profile_image.size[1]), fill=255,
-            )
-            h = (90 + 110 * i) * scale
-            base_image.paste(profile_image, (110 * scale, h), mask)
-
-        draw = ImageDraw.Draw(base_image)
-
-        # 文字設定
-        font_path = env_var.FONT_FILE_PATH
-        font_color = (255, 255, 255)
-
-        col_font_size = 20 * scale
-        col_font = ImageFont.truetype(font_path, col_font_size)
-
-        text = "累計得点"
-        w = 450 * scale
-        h = 50 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "参加半荘数"
-        w = 600 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "最高得点"
-        w = 775 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "平均素点"
-        w = 950 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        line_h = 65 * scale
-        draw.line((0, line_h, width, line_h), fill=(255, 255, 255), width=2)
-
-        font_size = 30 * scale
-        font = ImageFont.truetype(font_path, font_size)
-
-        for i, r in enumerate(sorted_total_dict):
-            h = (120 + 110 * i) * scale
-
-            text = str(i + 1)
-            w = 50 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text(
-                (x, y), text, font_color, font=font, stroke_width=1, align="center",
-            )
-
-            text = display_name_dict[r[0]]
-            w = 190 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="lm")
-            draw.text((x, y), text, font_color, font=font, align="left")
-
-            text = ("+" + str(r[1])) if r[1] > 0 else str(r[1])
-            w = 450 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            text = str(len(point_dict[r[0]]))
-            w = 600 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            if max_score_dict[r[0]] == dummy_min_score:
-                text = "-"
-            else:
-                m = max_score_dict[r[0]]
-                text = ("+" + str(m)) if m > 0 else str(m)
-            w = 775 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            if len(point_dict[r[0]]) == 0:
-                text = "-"
-            else:
-                text = str(int(sum(point_dict[r[0]]) / len(point_dict[r[0]])))
-            w = 950 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            line_h = (175 + 110 * i) * scale
-            draw.line((0, line_h, width, line_h), fill=(255, 255, 255), width=1)
-
-        path = f"/ranking_table/{req_line_user_id}_{datetime.now().strftime('%Y%m%d%H%M%S')}.png"
-        try:
-            base_image.save(f"src/uploads{path}", quality=75)
-        except FileNotFoundError:
-            reply_service.reset()
-            reply_service.add_message(text="システムエラーが発生しました。")
-            messages = [
-                "ランキングの画像アップロードに失敗しました",
-                "送信者: "
-                + (
-                    user_service.get_name_by_line_user_id(
-                        request_info_service.req_line_user_id,
-                    )
-                    or request_info_service.req_line_user_id
-                ),
-            ]
-            reply_service.push_a_message(
-                to=env_var.SERVER_ADMIN_LINE_USER_ID,
-                message="\n".join(messages),
-            )
-            return
-
-        reply_service.add_image(f"{env_var.SERVER_URL}/uploads{path}")
-
-        # 順位表画像生成
-        scale = 1
-        width, height = (
-            1024 * scale,
-            (768 + 110 * max(0, len(active_user_line_ids) - 6)) * scale,
-        )
-        bg_color = (33, 33, 33, 255)
-        base_image = Image.new("RGBA", (width, height), bg_color)
-
-        # 王冠画像添付
-        crowns_image = Image.new("RGBA", base_image.size, (255, 255, 255, 0))
-        gold = Image.open("src/static/images/ranking_table/crown_gold.png")
-        silver = Image.open("src/static/images/ranking_table/crown_silver.png")
-        bronze = Image.open("src/static/images/ranking_table/crown_bronze.png")
-        crowns = [(gold, 7, 77), (silver, 13, 190), (bronze, 7, 300)]
-        for i in range(min(3, len(active_user_line_ids))):
-            crowns_image.paste(
-                crowns[i][0], (crowns[i][1] * scale, crowns[i][2] * scale),
-            )
-        base_image = Image.alpha_composite(base_image, crowns_image)
-
-        sorted_ave_rank_dict = sorted(
-            ave_rank_dict.items(),
-            key=lambda x: x[1],
-            reverse=False,
-        )
-        for i, r in enumerate(sorted_ave_rank_dict):
-            profile_image = Image.open(f"src/uploads/profile_image/{r[0]}.jpeg")
-            profile_image = profile_image.resize((50 * scale, 50 * scale))
-            mask = Image.new("L", profile_image.size, 0)
-            draw_mask = ImageDraw.Draw(mask)
-            draw_mask.ellipse(
-                (0, 0, profile_image.size[0], profile_image.size[1]), fill=255,
-            )
-            h = (90 + 110 * i) * scale
-            base_image.paste(profile_image, (110 * scale, h), mask)
-
-        draw = ImageDraw.Draw(base_image)
-
-        # 文字設定
-        font_path = env_var.FONT_FILE_PATH
-        font_color = (255, 255, 255)
-
-        col_font_size = 20 * scale
-        col_font = ImageFont.truetype(font_path, col_font_size)
-
-        text = "平均順位"
-        w = 450 * scale
-        h = 50 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "1位"
-        w = 550 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "2位"
-        w = 650 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "3位"
-        w = 750 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "4位"
-        w = 850 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        text = "飛び"
-        w = 950 * scale
-        x, y, _x2, _y2 = draw.textbbox((w, h), text, font=col_font, anchor="mm")
-        draw.text((x, y), text, font_color, font=col_font, align="center")
-
-        w1 = 0 * scale
-        h1 = 65 * scale
-        w2 = 1024 * scale
-        h2 = h1
-        draw.line((w1, h1, w2, h2), fill=(255, 255, 255), width=2)
-
-        font_size = 30 * scale
-        font = ImageFont.truetype(font_path, font_size)
-
-        for i, r in enumerate(sorted_ave_rank_dict):
-            h = (120 + 110 * i) * scale
-
-            text = str(i + 1)
-            w = 50 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text(
-                (x, y), text, font_color, font=font, stroke_width=1, align="center",
-            )
-
-            text = display_name_dict[r[0]]
-            w = 190 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="lm")
-            draw.text((x, y), text, font_color, font=font, align="left")
-
-            text = ave_rank_str_dict[r[0]]
-            w = 450 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            text = str(rank_dict[r[0]][1])
-            w = 550 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            text = str(rank_dict[r[0]][2])
-            w = 650 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            text = str(rank_dict[r[0]][3])
-            w = 750 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            text = str(rank_dict[r[0]][4])
-            w = 850 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            text = str(rank_dict[r[0]][0])
-            w = 950 * scale
-            x, y, _x2, _y2 = draw.textbbox((w, h), text, font=font, anchor="mm")
-            draw.text((x, y), text, font_color, font=font, align="center")
-
-            line_h = (175 + 110 * i) * scale
-            draw.line((0, line_h, width, line_h), fill=(255, 255, 255), width=1)
-
-        path = f"/ranking_table_rank/{req_line_user_id}_{datetime.now().strftime('%Y%m%d%H%M%S')}.png"
-        try:
-            base_image.save(f"src/uploads{path}", quality=75)
-        except FileNotFoundError:
-            reply_service.reset()
-            reply_service.add_message(text="システムエラーが発生しました。")
-            messages = [
-                "ランキングの画像アップロードに失敗しました",
-                "送信者: "
-                + (
-                    user_service.get_name_by_line_user_id(
-                        request_info_service.req_line_user_id,
-                    )
-                    or request_info_service.req_line_user_id
-                ),
-            ]
-            reply_service.push_a_message(
-                to=env_var.SERVER_ADMIN_LINE_USER_ID,
-                message="\n".join(messages),
-            )
-            return
-
-        reply_service.add_image(f"{env_var.SERVER_URL}/uploads{path}")

--- a/src/use_cases/group_line/submit_hanchan_use_case.py
+++ b/src/use_cases/group_line/submit_hanchan_use_case.py
@@ -11,7 +11,7 @@ from application_service import (
 )
 from domain_model.entities.group import GroupMode
 from domain_model.entities.user_group import UserGroup
-from domain_model.entities.user_hanchan import UserHanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
 from domain_model.entities.user_match import UserMatch
 from domain_service import (
     group_service,
@@ -24,7 +24,6 @@ from domain_service import (
 from line_models.profile import Profile
 from repositories import (
     user_group_repository,
-    user_hanchan_repository,
     user_match_repository,
 )
 
@@ -161,19 +160,19 @@ class SubmitHanchanUseCase:
             active_match.sum_scores = sum_scores
             match_service.update(active_match)
 
-            # UserHanchan の作成
+            # hanchan.results に結果を embedded 保存
             sorted_points: list[tuple[str, int]] = sorted(
                 active_hanchan.raw_scores.items(), key=lambda x: x[1], reverse=True,
             )
-            for i, (line_id, point) in enumerate(sorted_points):
-                user_hanchan_repository.create(
-                    UserHanchan(
-                        line_user_id=line_id,
-                        hanchan_id=active_hanchan._id,
-                        point=point,
-                        rank=i + 1,
-                    ),
+            results = [
+                UserHanchanResult(
+                    line_user_id=line_id,
+                    point=point,
+                    rank=i + 1,
                 )
+                for i, (line_id, point) in enumerate(sorted_points)
+            ]
+            hanchan_service.set_results(active_hanchan._id, results)
 
         except pymongo.errors.PyMongoError as err:
             logger.exception("submit_hanchan: DB書き込み中にエラーが発生しました")

--- a/src/use_cases/group_line/update_group_settings_use_case.py
+++ b/src/use_cases/group_line/update_group_settings_use_case.py
@@ -3,7 +3,7 @@ from application_service import (
     request_info_service,
 )
 from domain_model.entities.group_setting import ROUNDING_METHOD_LIST
-from repositories import group_setting_repository
+from domain_service import group_service
 
 
 class UpdateGroupSettingsUseCase:
@@ -69,8 +69,5 @@ class UpdateGroupSettingsUseCase:
             reply_service.add_message(str(e))
             return
 
-        group_setting_repository.update(
-            {"line_group_id": target_id},
-            {column: db_value},
-        )
+        group_service.update_settings(target_id, column, db_value)
         reply_service.add_message(f"[{key}]を[{display_value}]に変更しました。")

--- a/src/use_cases/personal_line/reply_history_use_case.py
+++ b/src/use_cases/personal_line/reply_history_use_case.py
@@ -1,8 +1,5 @@
 from datetime import datetime, timedelta
 
-import matplotlib as mpl
-
-mpl.use("agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 
@@ -37,15 +34,12 @@ class ReplyHistoryUseCase:
                 "既に友達の場合は一度ブロックして、ブロック解除を行ってください。",
             )
             return
-        from_str = request_info_service.params.get("from")
-        to_str = request_info_service.params.get("to")
-        from_dt, from_is_invalid = message_service.parse_date_from_text(from_str)
-        to_dt, to_is_invalid = message_service.parse_date_from_text(to_str)
-        if from_is_invalid or to_is_invalid:
-            reply_service.add_message("日付は以下のフォーマットで入力してください。")
-            reply_service.add_message(
-                "[日付の入力方法]\n\nYYYY年MM月DD日\n→ YYYYMMDD\n\n20YY年MM月DD日\n→ YYMMDD\n\n今年MM月DD日\n→ MMDD\n\n今月DD日\n→ DD",
-            )
+        from_dt, to_dt, is_valid = message_service.parse_date_range_from_params(
+            request_info_service.params,
+        )
+        if not is_valid:
+            for msg in message_service.DATE_FORMAT_ERROR_MESSAGES:
+                reply_service.add_message(msg)
             return
         um_list = user_match_service.find_all_by_user_id_list(
             [users[0]._id],
@@ -133,8 +127,6 @@ class ReplyHistoryUseCase:
             ],
         )
         plt.xticks(rotation=30)
-        # locator = mdates.DayLocator()
-        # ax.xaxis.set_major_locator(locator)
         ax.xaxis.set_major_formatter(mdates.DateFormatter("%m/%d %H時"))
         plt.gca().spines["right"].set_visible(False)
         plt.gca().spines["top"].set_visible(False)

--- a/src/use_cases/web/delete_configs_for_web_use_case.py
+++ b/src/use_cases/web/delete_configs_for_web_use_case.py
@@ -6,7 +6,7 @@ from repositories import group_repository
 class DeleteConfigsForWebUseCase:
 
     def execute(self, line_group_ids: List[str]) -> None:
-        """指定グループの settings を削除（embedded を None にリセット）"""
+        """指定グループの settings を削除(embedded を None にリセット)"""
         for line_group_id in line_group_ids:
             group_repository.update(
                 {"line_group_id": line_group_id},

--- a/src/use_cases/web/delete_configs_for_web_use_case.py
+++ b/src/use_cases/web/delete_configs_for_web_use_case.py
@@ -1,11 +1,14 @@
 from typing import List
 
-from repositories import group_setting_repository
-
-from .web_utils import delete_by_ids
+from repositories import group_repository
 
 
 class DeleteConfigsForWebUseCase:
 
-    def execute(self, ids: List[int]) -> None:
-        delete_by_ids(group_setting_repository, ids)
+    def execute(self, line_group_ids: List[str]) -> None:
+        """指定グループの settings を削除（embedded を None にリセット）"""
+        for line_group_id in line_group_ids:
+            group_repository.update(
+                {"line_group_id": line_group_id},
+                {"settings": None},
+            )

--- a/src/use_cases/web/get_config_for_web_use_case.py
+++ b/src/use_cases/web/get_config_for_web_use_case.py
@@ -1,12 +1,15 @@
 from typing import Optional
 
-from domain_model.entities.group_setting import GroupSetting
-from repositories import group_setting_repository
+from domain_model.entities.group_setting import EmbeddedGroupSettings
+from repositories import group_repository
 
-from .web_utils import find_one_by_id
+from .web_utils import to_object_id
 
 
 class GetConfigForWebUseCase:
 
-    def execute(self, _id) -> Optional[GroupSetting]:
-        return find_one_by_id(group_setting_repository, _id)
+    def execute(self, line_group_id: str) -> Optional[EmbeddedGroupSettings]:
+        groups = group_repository.find({"line_group_id": line_group_id})
+        if not groups:
+            return None
+        return groups[0].settings or EmbeddedGroupSettings()

--- a/src/use_cases/web/get_config_for_web_use_case.py
+++ b/src/use_cases/web/get_config_for_web_use_case.py
@@ -3,13 +3,17 @@ from typing import Optional
 from domain_model.entities.group_setting import EmbeddedGroupSettings
 from repositories import group_repository
 
-from .web_utils import to_object_id
+_SETTINGS_FIELDS = ("rate", "ranking_prize", "chip_rate", "tobi_prize", "num_of_players", "rounding_method")
 
 
 class GetConfigForWebUseCase:
 
-    def execute(self, line_group_id: str) -> Optional[EmbeddedGroupSettings]:
+    def execute(self, line_group_id: str) -> Optional[dict]:
         groups = group_repository.find({"line_group_id": line_group_id})
         if not groups:
             return None
-        return groups[0].settings or EmbeddedGroupSettings()
+        g = groups[0]
+        s = g.settings or EmbeddedGroupSettings()
+        d: dict = {"_id": g.line_group_id, "line_group_id": g.line_group_id}
+        d.update({k: getattr(s, k) for k in _SETTINGS_FIELDS})
+        return d

--- a/src/use_cases/web/get_configs_for_web_use_case.py
+++ b/src/use_cases/web/get_configs_for_web_use_case.py
@@ -9,7 +9,7 @@ _SETTINGS_FIELDS = ("rate", "ranking_prize", "chip_rate", "tobi_prize", "num_of_
 class GetConfigsForWebUseCase:
 
     def execute(self) -> List[dict]:
-        """全グループの設定を返す（テンプレートが _id キーを参照できるよう dict で返す）"""
+        """全グループの設定を返す(テンプレートが _id キーを参照できるよう dict で返す)"""
         groups = group_repository.find()
         result = []
         for g in groups:

--- a/src/use_cases/web/get_configs_for_web_use_case.py
+++ b/src/use_cases/web/get_configs_for_web_use_case.py
@@ -1,10 +1,12 @@
 from typing import List
 
-from domain_model.entities.group_setting import GroupSetting
-from repositories import group_setting_repository
+from domain_model.entities.group_setting import EmbeddedGroupSettings
+from repositories import group_repository
 
 
 class GetConfigsForWebUseCase:
 
-    def execute(self) -> List[GroupSetting]:
-        return group_setting_repository.find()
+    def execute(self) -> List[EmbeddedGroupSettings]:
+        """全グループの設定を返す（embedded settings を使用）"""
+        groups = group_repository.find()
+        return [g.settings or EmbeddedGroupSettings() for g in groups]

--- a/src/use_cases/web/get_configs_for_web_use_case.py
+++ b/src/use_cases/web/get_configs_for_web_use_case.py
@@ -3,10 +3,18 @@ from typing import List
 from domain_model.entities.group_setting import EmbeddedGroupSettings
 from repositories import group_repository
 
+_SETTINGS_FIELDS = ("rate", "ranking_prize", "chip_rate", "tobi_prize", "num_of_players", "rounding_method")
+
 
 class GetConfigsForWebUseCase:
 
-    def execute(self) -> List[EmbeddedGroupSettings]:
-        """全グループの設定を返す（embedded settings を使用）"""
+    def execute(self) -> List[dict]:
+        """全グループの設定を返す（テンプレートが _id キーを参照できるよう dict で返す）"""
         groups = group_repository.find()
-        return [g.settings or EmbeddedGroupSettings() for g in groups]
+        result = []
+        for g in groups:
+            s = g.settings or EmbeddedGroupSettings()
+            d: dict = {"_id": g.line_group_id, "line_group_id": g.line_group_id}
+            d.update({k: getattr(s, k) for k in _SETTINGS_FIELDS})
+            result.append(d)
+        return result

--- a/src/use_cases/web/update_config_for_web_use_case.py
+++ b/src/use_cases/web/update_config_for_web_use_case.py
@@ -1,28 +1,26 @@
 from flask import request
 
-from repositories import group_setting_repository
+from domain_service import group_service
 
-from .web_utils import parse_int_list, to_object_id
+from .web_utils import parse_int_list
 
 
 class UpdateConfigForWebUseCase:
     def execute(self) -> None:
         form = request.form
-        target_id = to_object_id(form.get("_id"))
-        new_values = {}
-        if form.get("line_group_id") is not None:
-            new_values["line_group_id"] = form.get("line_group_id")
-        if form.get("rate") is not None:
-            new_values["rate"] = int(form.get("rate"))
-        if form.get("ranking_prize") is not None:
-            new_values["ranking_prize"] = parse_int_list(form.get("ranking_prize"))
-        if form.get("chip_rate") is not None:
-            new_values["chip_rate"] = int(form.get("chip_rate"))
-        if form.get("tobi_prize") is not None:
-            new_values["tobi_prize"] = int(form.get("tobi_prize"))
-        if form.get("num_of_players") is not None:
-            new_values["num_of_players"] = int(form.get("num_of_players"))
-        if form.get("rounding_method") is not None:
-            new_values["rounding_method"] = int(form.get("rounding_method"))
-        if new_values:
-            group_setting_repository.update({"_id": target_id}, new_values)
+        line_group_id = form.get("line_group_id")
+        if not line_group_id:
+            return
+
+        field_parsers = {
+            "rate": int,
+            "ranking_prize": parse_int_list,
+            "chip_rate": int,
+            "tobi_prize": int,
+            "num_of_players": int,
+            "rounding_method": int,
+        }
+        for column, parser in field_parsers.items():
+            raw = form.get(column)
+            if raw is not None:
+                group_service.update_settings(line_group_id, column, parser(raw))

--- a/tests/application_service/reply_service/test_reply_service_add_image.py
+++ b/tests/application_service/reply_service/test_reply_service_add_image.py
@@ -26,12 +26,12 @@ def test_success_messages():
     ]
 
     # Act
-    for i in range(len(dummy_image_urls)):
-        reply_service.add_image(dummy_image_urls[i])
+    for url in dummy_image_urls:
+        reply_service.add_image(url)
 
     # Assert
     assert len(reply_service.images) == len(dummy_image_urls)
-    for i in range(len(reply_service.images)):
-        assert reply_service.images[i].type == "image"
-        assert reply_service.images[i].original_content_url == dummy_image_urls[i]
-        assert reply_service.images[i].preview_image_url == dummy_image_urls[i]
+    for img, url in zip(reply_service.images, dummy_image_urls):
+        assert img.type == "image"
+        assert img.original_content_url == url
+        assert img.preview_image_url == url

--- a/tests/application_service/reply_service/test_reply_service_add_message.py
+++ b/tests/application_service/reply_service/test_reply_service_add_message.py
@@ -25,11 +25,11 @@ def test_success_messages():
     ]
 
     # Act
-    for i in range(len(dummy_texts)):
-        reply_service.add_message(dummy_texts[i])
+    for text in dummy_texts:
+        reply_service.add_message(text)
 
     # Assert
     assert len(reply_service.texts) == len(dummy_texts)
-    for i in range(len(reply_service.texts)):
-        assert reply_service.texts[i].type == "text"
-        assert reply_service.texts[i].text == dummy_texts[i]
+    for msg, expected_text in zip(reply_service.texts, dummy_texts):
+        assert msg.type == "text"
+        assert msg.text == expected_text

--- a/tests/domain_service/group_service/test_group_service_update.py
+++ b/tests/domain_service/group_service/test_group_service_update.py
@@ -34,6 +34,7 @@ def test_ok(mocker):
             "line_group_id": "G0123456789abcdefghijklmnopqrstu1",
             "mode": "wait",
             "active_match_id": None,
+            "settings": None,
             "created_at": datetime(2010,1,2,3,4,0,0),
             "updated_at": datetime(2010,1,2,3,4,0,0),
         },

--- a/tests/domain_service/group_setting_service/test_group_setting_service_find_or_create.py
+++ b/tests/domain_service/group_setting_service/test_group_setting_service_find_or_create.py
@@ -1,12 +1,14 @@
-from domain_model.entities.group_setting import GroupSetting
-from domain_service import (
-    group_setting_service,
-)
-from repositories import group_setting_repository
+from domain_model.entities.group import Group, GroupMode
+from domain_model.entities.group_setting import EmbeddedGroupSettings
+from domain_service import group_setting_service
+from repositories import group_repository
 
-dummy_group_settings = [
-    GroupSetting(
-        line_group_id="G0123456789abcdefghijklmnopqrstu1",
+dummy_line_group_id = "G0123456789abcdefghijklmnopqrstu1"
+
+dummy_group_with_settings = Group(
+    line_group_id=dummy_line_group_id,
+    mode=GroupMode.wait.value,
+    settings=EmbeddedGroupSettings(
         rate=0,
         ranking_prize=[20, 10, -10, -20],
         chip_rate=0,
@@ -14,43 +16,47 @@ dummy_group_settings = [
         num_of_players=4,
         rounding_method=0,
     ),
-]
+)
+
+dummy_group_without_settings = Group(
+    line_group_id=dummy_line_group_id,
+    mode=GroupMode.wait.value,
+    settings=None,
+)
 
 
 def test_ok_hit_group_setting(mocker):
-    # Arrange
+    # group.settings が設定済みの場合、settings がそのまま返り update は呼ばれないこと
     mocker.patch.object(
-        group_setting_repository,
+        group_repository,
         "find",
-        return_value=dummy_group_settings,
+        return_value=[dummy_group_with_settings],
     )
-    mock_create = mocker.patch.object(
-        group_setting_repository,
-        "create",
-        return_value=dummy_group_settings[0],
+    mock_update_settings = mocker.patch.object(
+        group_repository,
+        "update_settings",
     )
 
-    # Act
-    result = group_setting_service.find_or_create("G0123456789abcdefghijklmnopqrstu1")
+    result = group_setting_service.find_or_create(dummy_line_group_id)
 
-    # Assert
-    assert isinstance(result, GroupSetting)
-    assert result.line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    mock_create.assert_not_called()
+    assert isinstance(result, EmbeddedGroupSettings)
+    assert result.rate == 0
+    mock_update_settings.assert_not_called()
 
 
 def test_ok_no_group_setting(mocker):
-    # Arrange
-    mock_find_or_create = mocker.patch.object(
-        group_setting_repository,
-        "find_or_create",
-        return_value=dummy_group_settings[0],
+    # group は存在するが settings が None の場合、デフォルト設定が保存されて返ること
+    mocker.patch.object(
+        group_repository,
+        "find",
+        return_value=[dummy_group_without_settings],
+    )
+    mock_update_settings = mocker.patch.object(
+        group_repository,
+        "update_settings",
     )
 
-    # Act
-    result = group_setting_service.find_or_create("G0123456789abcdefghijklmnopqrstu1")
+    result = group_setting_service.find_or_create(dummy_line_group_id)
 
-    # Assert
-    assert isinstance(result, GroupSetting)
-    assert result.line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    mock_find_or_create.assert_called_once()
+    assert isinstance(result, EmbeddedGroupSettings)
+    mock_update_settings.assert_called_once()

--- a/tests/domain_service/hanchan_service/test_hanchan_service_disable_by_match_id.py
+++ b/tests/domain_service/hanchan_service/test_hanchan_service_disable_by_match_id.py
@@ -15,9 +15,9 @@ dummy_hanchans = [
 
 def test_ok_hit(mocker):
     # Arrange
-    mock_update = mocker.patch.object(
+    mock_update_many = mocker.patch.object(
         hanchan_repository,
-        "update",
+        "update_many",
         return_value=1,
     )
 
@@ -25,7 +25,7 @@ def test_ok_hit(mocker):
     hanchan_service.disable_by_match_id(dummy_hanchans[0].match_id)
 
     # Assert
-    mock_update.assert_called_once_with(
+    mock_update_many.assert_called_once_with(
         {"match_id": 1},
         {"is_deleted": True},
     )

--- a/tests/domain_service/hanchan_service/test_hanchan_service_find_all_archived_by_match_id.py
+++ b/tests/domain_service/hanchan_service/test_hanchan_service_find_all_archived_by_match_id.py
@@ -35,8 +35,8 @@ def test_ok_hit_hanchan(mocker):
     assert len(result) == len(dummy_hanchans)
     for i, _item in enumerate(dummy_hanchans):
         assert isinstance(result[i], Hanchan)
-        assert result[i]._id == dummy_hanchans[i]._id
-        assert result[i].match_id == dummy_hanchans[i].match_id
-        assert result[i].line_group_id == dummy_hanchans[i].line_group_id
-        assert result[i].is_deleted == dummy_hanchans[i].is_deleted
+        assert result[i]._id == _item._id
+        assert result[i].match_id == _item.match_id
+        assert result[i].line_group_id == _item.line_group_id
+        assert result[i].is_deleted == _item.is_deleted
     mock_find.assert_called_once_with({"match_id": 1, "converted_scores": {"$ne": {}}}, [("_id", ASCENDING)])

--- a/tests/domain_service/hanchan_service/test_hanchan_service_find_all_archived_by_match_id.py
+++ b/tests/domain_service/hanchan_service/test_hanchan_service_find_all_archived_by_match_id.py
@@ -33,7 +33,7 @@ def test_ok_hit_hanchan(mocker):
 
     # Assert
     assert len(result) == len(dummy_hanchans)
-    for i in range(len(dummy_hanchans)):
+    for i, _item in enumerate(dummy_hanchans):
         assert isinstance(result[i], Hanchan)
         assert result[i]._id == dummy_hanchans[i]._id
         assert result[i].match_id == dummy_hanchans[i].match_id

--- a/tests/domain_service/user_hanchan_service/test_user_hanchan_service_find_all_each_line_user_id.py
+++ b/tests/domain_service/user_hanchan_service/test_user_hanchan_service_find_all_each_line_user_id.py
@@ -1,99 +1,120 @@
 from datetime import datetime
 
-from domain_model.entities.user_hanchan import UserHanchan
-from domain_service import (
-    user_hanchan_service,
-)
-from repositories import user_hanchan_repository
+from bson.objectid import ObjectId
 
-dummy_user_hanchan = UserHanchan(
-        _id=1,
-        line_user_id="U0123456789abcdefghijklmnopqrstu1",
-        hanchan_id=1,
-        point=1000,
-        rank=4,
-    )
+from domain_model.entities.hanchan import Hanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
+from domain_service import user_hanchan_service
+from repositories import hanchan_repository
+
+dummy_hanchan_id = ObjectId("000000000000000000000001")
+
+dummy_hanchan = Hanchan(
+    line_group_id="G0123456789abcdefghijklmnopqrstu1",
+    match_id=1,
+    results=[
+        UserHanchanResult(line_user_id="U0123456789abcdefghijklmnopqrstu1", rank=4, point=1000),
+    ],
+    _id=dummy_hanchan_id,
+    created_at=datetime(2022, 1, 2, 3, 4, 5),
+)
 
 
 def test_ok_with_no_query(mocker):
     # Arrange
     mock_find = mocker.patch.object(
-        user_hanchan_repository,
+        hanchan_repository,
         "find",
-        return_value=[dummy_user_hanchan],
+        return_value=[dummy_hanchan],
     )
 
     # Act
-    result = user_hanchan_service.find_all_each_line_user_id("G0123456789abcdefghijklmnopqrstu1")
+    result = user_hanchan_service.find_all_each_line_user_id(["U0123456789abcdefghijklmnopqrstu1"])
 
     # Assert
     assert len(result) == 1
-    assert result[0]._id == dummy_user_hanchan._id
-    assert result[0].line_user_id == dummy_user_hanchan.line_user_id
-    assert result[0].hanchan_id == dummy_user_hanchan.hanchan_id
-    assert result[0].point == dummy_user_hanchan.point
-    assert result[0].rank == dummy_user_hanchan.rank
-    mock_find.assert_called_once_with(query={"$and": [{"line_user_id": {"$in": "G0123456789abcdefghijklmnopqrstu1"}}]}, sort=[("hanchan_id", 1)])
+    assert result[0].line_user_id == "U0123456789abcdefghijklmnopqrstu1"
+    assert result[0].hanchan_id == dummy_hanchan_id
+    assert result[0].point == 1000
+    assert result[0].rank == 4
+    mock_find.assert_called_once_with(
+        query={"$and": [{"results": {"$elemMatch": {"line_user_id": {"$in": ["U0123456789abcdefghijklmnopqrstu1"]}}}}]},
+        sort=[("_id", 1)],
+    )
 
 
 def test_ok_with_from_query(mocker):
     # Arrange
     mock_find = mocker.patch.object(
-        user_hanchan_repository,
+        hanchan_repository,
         "find",
-        return_value=[dummy_user_hanchan],
+        return_value=[dummy_hanchan],
     )
 
     # Act
-    result = user_hanchan_service.find_all_each_line_user_id("G0123456789abcdefghijklmnopqrstu1", from_dt=datetime(2022,1,2,3,4,5))
+    result = user_hanchan_service.find_all_each_line_user_id(
+        ["U0123456789abcdefghijklmnopqrstu1"],
+        from_dt=datetime(2022, 1, 2, 3, 4, 5),
+    )
 
     # Assert
     assert len(result) == 1
-    assert result[0]._id == dummy_user_hanchan._id
-    assert result[0].line_user_id == dummy_user_hanchan.line_user_id
-    assert result[0].hanchan_id == dummy_user_hanchan.hanchan_id
-    assert result[0].point == dummy_user_hanchan.point
-    assert result[0].rank == dummy_user_hanchan.rank
-    mock_find.assert_called_once_with(query={"$and": [{"line_user_id": {"$in": "G0123456789abcdefghijklmnopqrstu1"}}, {"created_at": {"$gte": datetime(2022, 1, 2, 3, 4, 5)}}]}, sort=[("hanchan_id", 1)])
+    mock_find.assert_called_once_with(
+        query={"$and": [
+            {"results": {"$elemMatch": {"line_user_id": {"$in": ["U0123456789abcdefghijklmnopqrstu1"]}}}},
+            {"created_at": {"$gte": datetime(2022, 1, 2, 3, 4, 5)}},
+        ]},
+        sort=[("_id", 1)],
+    )
 
 
 def test_ok_with_to_query(mocker):
     # Arrange
     mock_find = mocker.patch.object(
-        user_hanchan_repository,
+        hanchan_repository,
         "find",
-        return_value=[dummy_user_hanchan],
+        return_value=[dummy_hanchan],
     )
 
     # Act
-    result = user_hanchan_service.find_all_each_line_user_id("G0123456789abcdefghijklmnopqrstu1", to_dt=datetime(2022,1,2,3,4,5))
+    result = user_hanchan_service.find_all_each_line_user_id(
+        ["U0123456789abcdefghijklmnopqrstu1"],
+        to_dt=datetime(2022, 1, 2, 3, 4, 5),
+    )
 
     # Assert
     assert len(result) == 1
-    assert result[0]._id == dummy_user_hanchan._id
-    assert result[0].line_user_id == dummy_user_hanchan.line_user_id
-    assert result[0].hanchan_id == dummy_user_hanchan.hanchan_id
-    assert result[0].point == dummy_user_hanchan.point
-    assert result[0].rank == dummy_user_hanchan.rank
-    mock_find.assert_called_once_with(query={"$and": [{"line_user_id": {"$in": "G0123456789abcdefghijklmnopqrstu1"}}, {"created_at": {"$lte": datetime(2022, 1, 2, 3, 4, 5)}}]}, sort=[("hanchan_id", 1)])
+    mock_find.assert_called_once_with(
+        query={"$and": [
+            {"results": {"$elemMatch": {"line_user_id": {"$in": ["U0123456789abcdefghijklmnopqrstu1"]}}}},
+            {"created_at": {"$lte": datetime(2022, 1, 2, 3, 4, 5)}},
+        ]},
+        sort=[("_id", 1)],
+    )
 
 
 def test_ok_with_both_query(mocker):
     # Arrange
     mock_find = mocker.patch.object(
-        user_hanchan_repository,
+        hanchan_repository,
         "find",
-        return_value=[dummy_user_hanchan],
+        return_value=[dummy_hanchan],
     )
 
     # Act
-    result = user_hanchan_service.find_all_each_line_user_id("G0123456789abcdefghijklmnopqrstu1", from_dt=datetime(2022,1,2,3,4,5), to_dt=datetime(2023,1,2,3,4,5))
+    result = user_hanchan_service.find_all_each_line_user_id(
+        ["U0123456789abcdefghijklmnopqrstu1"],
+        from_dt=datetime(2022, 1, 2, 3, 4, 5),
+        to_dt=datetime(2023, 1, 2, 3, 4, 5),
+    )
 
     # Assert
     assert len(result) == 1
-    assert result[0]._id == dummy_user_hanchan._id
-    assert result[0].line_user_id == dummy_user_hanchan.line_user_id
-    assert result[0].hanchan_id == dummy_user_hanchan.hanchan_id
-    assert result[0].point == dummy_user_hanchan.point
-    assert result[0].rank == dummy_user_hanchan.rank
-    mock_find.assert_called_once_with(query={"$and": [{"line_user_id": {"$in": "G0123456789abcdefghijklmnopqrstu1"}}, {"created_at": {"$gte": datetime(2022, 1, 2, 3, 4, 5)}}, {"created_at": {"$lte": datetime(2023, 1, 2, 3, 4, 5)}}]}, sort=[("hanchan_id", 1)])
+    mock_find.assert_called_once_with(
+        query={"$and": [
+            {"results": {"$elemMatch": {"line_user_id": {"$in": ["U0123456789abcdefghijklmnopqrstu1"]}}}},
+            {"created_at": {"$gte": datetime(2022, 1, 2, 3, 4, 5)}},
+            {"created_at": {"$lte": datetime(2023, 1, 2, 3, 4, 5)}},
+        ]},
+        sort=[("_id", 1)],
+    )

--- a/tests/repositories/group_repository/test_group_repository_delete.py
+++ b/tests/repositories/group_repository/test_group_repository_delete.py
@@ -24,8 +24,8 @@ def test_hit_with_ids():
     record_on_db = group_repository.find()
     assert len(record_on_db) == len(other_groups)
     for i, _item in enumerate(record_on_db):
-        assert record_on_db[i].line_group_id == other_groups[i].line_group_id
-        assert record_on_db[i].mode == other_groups[i].mode
+        assert _item.line_group_id == other_groups[i].line_group_id
+        assert _item.mode == other_groups[i].mode
 
 
 def test_hit_0_record():
@@ -48,5 +48,5 @@ def test_hit_0_record():
     record_on_db = group_repository.find()
     assert len(record_on_db) == len(dummy_groups)
     for i, _item in enumerate(record_on_db):
-        assert record_on_db[i].line_group_id == dummy_groups[i].line_group_id
-        assert record_on_db[i].mode == dummy_groups[i].mode
+        assert _item.line_group_id == dummy_groups[i].line_group_id
+        assert _item.mode == dummy_groups[i].mode

--- a/tests/repositories/group_repository/test_group_repository_delete.py
+++ b/tests/repositories/group_repository/test_group_repository_delete.py
@@ -23,7 +23,7 @@ def test_hit_with_ids():
     assert result == len(target_groups)
     record_on_db = group_repository.find()
     assert len(record_on_db) == len(other_groups)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert record_on_db[i].line_group_id == other_groups[i].line_group_id
         assert record_on_db[i].mode == other_groups[i].mode
 
@@ -47,6 +47,6 @@ def test_hit_0_record():
     assert result == 0
     record_on_db = group_repository.find()
     assert len(record_on_db) == len(dummy_groups)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert record_on_db[i].line_group_id == dummy_groups[i].line_group_id
         assert record_on_db[i].mode == dummy_groups[i].mode

--- a/tests/repositories/group_repository/test_group_repository_find.py
+++ b/tests/repositories/group_repository/test_group_repository_find.py
@@ -18,7 +18,7 @@ def test_success_find_records():
 
     # Assert
     assert len(result) == len(dummy_groups)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert isinstance(result[i], Group)
         assert type(result[i]._id) is ObjectId
         assert result[i].line_group_id == dummy_groups[i].line_group_id

--- a/tests/repositories/group_repository/test_group_repository_find.py
+++ b/tests/repositories/group_repository/test_group_repository_find.py
@@ -19,10 +19,10 @@ def test_success_find_records():
     # Assert
     assert len(result) == len(dummy_groups)
     for i, _item in enumerate(result):
-        assert isinstance(result[i], Group)
-        assert type(result[i]._id) is ObjectId
-        assert result[i].line_group_id == dummy_groups[i].line_group_id
-        assert result[i].mode == dummy_groups[i].mode
+        assert isinstance(_item, Group)
+        assert type(_item._id) is ObjectId
+        assert _item.line_group_id == dummy_groups[i].line_group_id
+        assert _item.mode == dummy_groups[i].mode
 
 
 def test_hit_0_record():

--- a/tests/repositories/group_setting_repository/test_group_setting_repository_delete.py
+++ b/tests/repositories/group_setting_repository/test_group_setting_repository_delete.py
@@ -23,7 +23,7 @@ def test_hit_with_ids():
     assert result == len(target_groups)
     record_on_db = group_setting_repository.find()
     assert len(record_on_db) == len(other_groups)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert record_on_db[i].line_group_id == other_groups[i].line_group_id
         assert record_on_db[i].ranking_prize == other_groups[i].ranking_prize
         assert record_on_db[i].chip_rate == other_groups[i].chip_rate
@@ -51,7 +51,7 @@ def test_hit_0_record():
     assert result == 0
     record_on_db = group_setting_repository.find()
     assert len(record_on_db) == len(dummy_group_settings)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert record_on_db[i].line_group_id == dummy_group_settings[i].line_group_id
         assert record_on_db[i].ranking_prize == dummy_group_settings[i].ranking_prize
         assert record_on_db[i].chip_rate == dummy_group_settings[i].chip_rate

--- a/tests/repositories/group_setting_repository/test_group_setting_repository_delete.py
+++ b/tests/repositories/group_setting_repository/test_group_setting_repository_delete.py
@@ -24,12 +24,12 @@ def test_hit_with_ids():
     record_on_db = group_setting_repository.find()
     assert len(record_on_db) == len(other_groups)
     for i, _item in enumerate(record_on_db):
-        assert record_on_db[i].line_group_id == other_groups[i].line_group_id
-        assert record_on_db[i].ranking_prize == other_groups[i].ranking_prize
-        assert record_on_db[i].chip_rate == other_groups[i].chip_rate
-        assert record_on_db[i].tobi_prize == other_groups[i].tobi_prize
-        assert record_on_db[i].num_of_players == other_groups[i].num_of_players
-        assert record_on_db[i].rounding_method == other_groups[i].rounding_method
+        assert _item.line_group_id == other_groups[i].line_group_id
+        assert _item.ranking_prize == other_groups[i].ranking_prize
+        assert _item.chip_rate == other_groups[i].chip_rate
+        assert _item.tobi_prize == other_groups[i].tobi_prize
+        assert _item.num_of_players == other_groups[i].num_of_players
+        assert _item.rounding_method == other_groups[i].rounding_method
 
 
 def test_hit_0_record():
@@ -52,11 +52,11 @@ def test_hit_0_record():
     record_on_db = group_setting_repository.find()
     assert len(record_on_db) == len(dummy_group_settings)
     for i, _item in enumerate(record_on_db):
-        assert record_on_db[i].line_group_id == dummy_group_settings[i].line_group_id
-        assert record_on_db[i].ranking_prize == dummy_group_settings[i].ranking_prize
-        assert record_on_db[i].chip_rate == dummy_group_settings[i].chip_rate
-        assert record_on_db[i].tobi_prize == dummy_group_settings[i].tobi_prize
-        assert record_on_db[i].num_of_players == dummy_group_settings[i].num_of_players
+        assert _item.line_group_id == dummy_group_settings[i].line_group_id
+        assert _item.ranking_prize == dummy_group_settings[i].ranking_prize
+        assert _item.chip_rate == dummy_group_settings[i].chip_rate
+        assert _item.tobi_prize == dummy_group_settings[i].tobi_prize
+        assert _item.num_of_players == dummy_group_settings[i].num_of_players
         assert (
-            record_on_db[i].rounding_method == dummy_group_settings[i].rounding_method
+            _item.rounding_method == dummy_group_settings[i].rounding_method
         )

--- a/tests/repositories/group_setting_repository/test_group_setting_repository_find.py
+++ b/tests/repositories/group_setting_repository/test_group_setting_repository_find.py
@@ -18,7 +18,7 @@ def test_success_find_records():
 
     # Assert
     assert len(result) == len(dummy_group_settings)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert isinstance(result[i], GroupSetting)
         assert type(result[i]._id) is ObjectId
         assert result[i].line_group_id == dummy_group_settings[i].line_group_id

--- a/tests/repositories/group_setting_repository/test_group_setting_repository_find.py
+++ b/tests/repositories/group_setting_repository/test_group_setting_repository_find.py
@@ -19,14 +19,14 @@ def test_success_find_records():
     # Assert
     assert len(result) == len(dummy_group_settings)
     for i, _item in enumerate(result):
-        assert isinstance(result[i], GroupSetting)
-        assert type(result[i]._id) is ObjectId
-        assert result[i].line_group_id == dummy_group_settings[i].line_group_id
-        assert result[i].ranking_prize == dummy_group_settings[i].ranking_prize
-        assert result[i].chip_rate == dummy_group_settings[i].chip_rate
-        assert result[i].tobi_prize == dummy_group_settings[i].tobi_prize
-        assert result[i].num_of_players == dummy_group_settings[i].num_of_players
-        assert result[i].rounding_method == dummy_group_settings[i].rounding_method
+        assert isinstance(_item, GroupSetting)
+        assert type(_item._id) is ObjectId
+        assert _item.line_group_id == dummy_group_settings[i].line_group_id
+        assert _item.ranking_prize == dummy_group_settings[i].ranking_prize
+        assert _item.chip_rate == dummy_group_settings[i].chip_rate
+        assert _item.tobi_prize == dummy_group_settings[i].tobi_prize
+        assert _item.num_of_players == dummy_group_settings[i].num_of_players
+        assert _item.rounding_method == dummy_group_settings[i].rounding_method
 
 
 def test_hit_0_record():

--- a/tests/repositories/hanchan_repository/test_hanchan_repository_delete.py
+++ b/tests/repositories/hanchan_repository/test_hanchan_repository_delete.py
@@ -29,7 +29,7 @@ def test_hit_with_line_group_id():
     assert result == 2
     record_on_db = hanchan_repository.find()
     assert len(record_on_db) == 1
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
         assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
         assert record_on_db[i].raw_scores == other_hanchans[i].raw_scores
@@ -61,7 +61,7 @@ def test_hit_0_record():
     assert result == 0
     record_on_db = hanchan_repository.find()
     assert len(record_on_db) == len(other_hanchans)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
         assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
         assert record_on_db[i].raw_scores == other_hanchans[i].raw_scores

--- a/tests/repositories/hanchan_repository/test_hanchan_repository_delete.py
+++ b/tests/repositories/hanchan_repository/test_hanchan_repository_delete.py
@@ -30,12 +30,12 @@ def test_hit_with_line_group_id():
     record_on_db = hanchan_repository.find()
     assert len(record_on_db) == 1
     for i, _item in enumerate(record_on_db):
-        assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
-        assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
-        assert record_on_db[i].raw_scores == other_hanchans[i].raw_scores
-        assert record_on_db[i].converted_scores == other_hanchans[i].converted_scores
-        assert record_on_db[i].match_id == other_hanchans[i].match_id
-        assert record_on_db[i].is_deleted == other_hanchans[i].is_deleted
+        assert _item.line_group_id == other_hanchans[i].line_group_id
+        assert _item.line_group_id == other_hanchans[i].line_group_id
+        assert _item.raw_scores == other_hanchans[i].raw_scores
+        assert _item.converted_scores == other_hanchans[i].converted_scores
+        assert _item.match_id == other_hanchans[i].match_id
+        assert _item.is_deleted == other_hanchans[i].is_deleted
 
 
 def test_hit_0_record():
@@ -62,9 +62,9 @@ def test_hit_0_record():
     record_on_db = hanchan_repository.find()
     assert len(record_on_db) == len(other_hanchans)
     for i, _item in enumerate(record_on_db):
-        assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
-        assert record_on_db[i].line_group_id == other_hanchans[i].line_group_id
-        assert record_on_db[i].raw_scores == other_hanchans[i].raw_scores
-        assert record_on_db[i].converted_scores == other_hanchans[i].converted_scores
-        assert record_on_db[i].match_id == other_hanchans[i].match_id
-        assert record_on_db[i].is_deleted == other_hanchans[i].is_deleted
+        assert _item.line_group_id == other_hanchans[i].line_group_id
+        assert _item.line_group_id == other_hanchans[i].line_group_id
+        assert _item.raw_scores == other_hanchans[i].raw_scores
+        assert _item.converted_scores == other_hanchans[i].converted_scores
+        assert _item.match_id == other_hanchans[i].match_id
+        assert _item.is_deleted == other_hanchans[i].is_deleted

--- a/tests/repositories/hanchan_repository/test_hanchan_repository_find.py
+++ b/tests/repositories/hanchan_repository/test_hanchan_repository_find.py
@@ -31,7 +31,7 @@ def test_success_find_records():
 
     # Assert
     assert len(result) == len(target_hanchans)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert isinstance(result[i], Hanchan)
         assert type(result[0]._id) is ObjectId
         assert result[i].line_group_id == target_hanchans[i].line_group_id

--- a/tests/repositories/hanchan_repository/test_hanchan_repository_find.py
+++ b/tests/repositories/hanchan_repository/test_hanchan_repository_find.py
@@ -32,13 +32,13 @@ def test_success_find_records():
     # Assert
     assert len(result) == len(target_hanchans)
     for i, _item in enumerate(result):
-        assert isinstance(result[i], Hanchan)
+        assert isinstance(_item, Hanchan)
         assert type(result[0]._id) is ObjectId
-        assert result[i].line_group_id == target_hanchans[i].line_group_id
-        assert result[i].match_id == target_hanchans[i].match_id
-        assert result[i].raw_scores == target_hanchans[i].raw_scores
-        assert result[i].converted_scores == target_hanchans[i].converted_scores
-        assert result[i].is_deleted == target_hanchans[i].is_deleted
+        assert _item.line_group_id == target_hanchans[i].line_group_id
+        assert _item.match_id == target_hanchans[i].match_id
+        assert _item.raw_scores == target_hanchans[i].raw_scores
+        assert _item.converted_scores == target_hanchans[i].converted_scores
+        assert _item.is_deleted == target_hanchans[i].is_deleted
 
 
 def test_hit_1_record():

--- a/tests/repositories/match_repository/test_match_repository_delete.py
+++ b/tests/repositories/match_repository/test_match_repository_delete.py
@@ -49,6 +49,6 @@ def test_hit_0_record():
     record_on_db = match_repository.find()
     assert len(record_on_db) == len(target_matches)
     for i, _item in enumerate(record_on_db):
-        assert isinstance(record_on_db[i], Match)
-        assert record_on_db[i].line_group_id == target_matches[i].line_group_id
-        assert record_on_db[i].is_deleted == target_matches[i].is_deleted
+        assert isinstance(_item, Match)
+        assert _item.line_group_id == target_matches[i].line_group_id
+        assert _item.is_deleted == target_matches[i].is_deleted

--- a/tests/repositories/match_repository/test_match_repository_delete.py
+++ b/tests/repositories/match_repository/test_match_repository_delete.py
@@ -48,7 +48,7 @@ def test_hit_0_record():
     assert result == 0
     record_on_db = match_repository.find()
     assert len(record_on_db) == len(target_matches)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert isinstance(record_on_db[i], Match)
         assert record_on_db[i].line_group_id == target_matches[i].line_group_id
         assert record_on_db[i].is_deleted == target_matches[i].is_deleted

--- a/tests/repositories/match_repository/test_match_repository_find.py
+++ b/tests/repositories/match_repository/test_match_repository_find.py
@@ -23,7 +23,7 @@ def test_success_find_records():
 
     # Assert
     assert len(result) == len(target_matches)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert isinstance(result[i], Match)
         assert type(result[i]._id) is ObjectId
         assert result[i].line_group_id == target_matches[i].line_group_id
@@ -61,7 +61,7 @@ def test_hit_records():
 
     # Assert
     assert len(result) == len(target_matches)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert isinstance(result[i], Match)
         assert type(result[i]._id) is ObjectId
         assert result[i].line_group_id == target_matches[i].line_group_id

--- a/tests/repositories/match_repository/test_match_repository_find.py
+++ b/tests/repositories/match_repository/test_match_repository_find.py
@@ -24,10 +24,10 @@ def test_success_find_records():
     # Assert
     assert len(result) == len(target_matches)
     for i, _item in enumerate(result):
-        assert isinstance(result[i], Match)
-        assert type(result[i]._id) is ObjectId
-        assert result[i].line_group_id == target_matches[i].line_group_id
-        assert result[i].is_deleted == target_matches[i].is_deleted
+        assert isinstance(_item, Match)
+        assert type(_item._id) is ObjectId
+        assert _item.line_group_id == target_matches[i].line_group_id
+        assert _item.is_deleted == target_matches[i].is_deleted
 
 
 def test_success_find_0_record():
@@ -62,10 +62,10 @@ def test_hit_records():
     # Assert
     assert len(result) == len(target_matches)
     for i, _item in enumerate(result):
-        assert isinstance(result[i], Match)
-        assert type(result[i]._id) is ObjectId
-        assert result[i].line_group_id == target_matches[i].line_group_id
-        assert result[i].is_deleted == target_matches[i].is_deleted
+        assert isinstance(_item, Match)
+        assert type(_item._id) is ObjectId
+        assert _item.line_group_id == target_matches[i].line_group_id
+        assert _item.is_deleted == target_matches[i].is_deleted
 
 
 def test_hit_0_record_with_not_exist_line_group_id():

--- a/tests/repositories/user_group_repository/test_user_group_repository_find.py
+++ b/tests/repositories/user_group_repository/test_user_group_repository_find.py
@@ -56,8 +56,8 @@ def test_success():
     # Assert
     assert len(result) == len(dummy_user_groups)
     for i, _item in enumerate(result):
-        assert result[i].line_user_id == dummy_user_groups[i].line_user_id
-        assert result[i].line_group_id == dummy_user_groups[i].line_group_id
+        assert _item.line_user_id == dummy_user_groups[i].line_user_id
+        assert _item.line_group_id == dummy_user_groups[i].line_group_id
 
 
 def test_success_with_filter():
@@ -157,5 +157,5 @@ def test_success_with_sort():
     ]
     assert len(result) == len(expected)
     for i, _item in enumerate(result):
-        assert result[i].line_user_id == expected[i].line_user_id
-        assert result[i].line_group_id == expected[i].line_group_id
+        assert _item.line_user_id == expected[i].line_user_id
+        assert _item.line_group_id == expected[i].line_group_id

--- a/tests/repositories/user_group_repository/test_user_group_repository_find.py
+++ b/tests/repositories/user_group_repository/test_user_group_repository_find.py
@@ -55,7 +55,7 @@ def test_success():
 
     # Assert
     assert len(result) == len(dummy_user_groups)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert result[i].line_user_id == dummy_user_groups[i].line_user_id
         assert result[i].line_group_id == dummy_user_groups[i].line_group_id
 
@@ -156,6 +156,6 @@ def test_success_with_sort():
         ),
     ]
     assert len(result) == len(expected)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert result[i].line_user_id == expected[i].line_user_id
         assert result[i].line_group_id == expected[i].line_group_id

--- a/tests/repositories/user_hanchan_repository/test_user_hanchan_repository_find.py
+++ b/tests/repositories/user_hanchan_repository/test_user_hanchan_repository_find.py
@@ -61,7 +61,7 @@ def test_success():
 
     # Assert
     assert len(result) == len(dummy_user_hanchans)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert result[i].line_user_id == dummy_user_hanchans[i].line_user_id
         assert result[i].hanchan_id == dummy_user_hanchans[i].hanchan_id
 
@@ -178,6 +178,6 @@ def test_success_with_sort():
         ),
     ]
     assert len(result) == len(expected)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert result[i].line_user_id == expected[i].line_user_id
         assert result[i].hanchan_id == expected[i].hanchan_id

--- a/tests/repositories/user_hanchan_repository/test_user_hanchan_repository_find.py
+++ b/tests/repositories/user_hanchan_repository/test_user_hanchan_repository_find.py
@@ -62,8 +62,8 @@ def test_success():
     # Assert
     assert len(result) == len(dummy_user_hanchans)
     for i, _item in enumerate(result):
-        assert result[i].line_user_id == dummy_user_hanchans[i].line_user_id
-        assert result[i].hanchan_id == dummy_user_hanchans[i].hanchan_id
+        assert _item.line_user_id == dummy_user_hanchans[i].line_user_id
+        assert _item.hanchan_id == dummy_user_hanchans[i].hanchan_id
 
 
 def test_success_with_filter():
@@ -179,5 +179,5 @@ def test_success_with_sort():
     ]
     assert len(result) == len(expected)
     for i, _item in enumerate(result):
-        assert result[i].line_user_id == expected[i].line_user_id
-        assert result[i].hanchan_id == expected[i].hanchan_id
+        assert _item.line_user_id == expected[i].line_user_id
+        assert _item.hanchan_id == expected[i].hanchan_id

--- a/tests/repositories/user_match_repository/test_user_match_repository_find.py
+++ b/tests/repositories/user_match_repository/test_user_match_repository_find.py
@@ -56,8 +56,8 @@ def test_success():
     # Assert
     assert len(result) == len(dummy_user_matches)
     for i, _item in enumerate(result):
-        assert result[i].user_id == dummy_user_matches[i].user_id
-        assert result[i].match_id == dummy_user_matches[i].match_id
+        assert _item.user_id == dummy_user_matches[i].user_id
+        assert _item.match_id == dummy_user_matches[i].match_id
 
 
 def test_success_with_filter():
@@ -157,5 +157,5 @@ def test_success_with_sort():
     ]
     assert len(result) == len(expected)
     for i, _item in enumerate(result):
-        assert result[i].user_id == expected[i].user_id
-        assert result[i].match_id == expected[i].match_id
+        assert _item.user_id == expected[i].user_id
+        assert _item.match_id == expected[i].match_id

--- a/tests/repositories/user_match_repository/test_user_match_repository_find.py
+++ b/tests/repositories/user_match_repository/test_user_match_repository_find.py
@@ -55,7 +55,7 @@ def test_success():
 
     # Assert
     assert len(result) == len(dummy_user_matches)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert result[i].user_id == dummy_user_matches[i].user_id
         assert result[i].match_id == dummy_user_matches[i].match_id
 
@@ -156,6 +156,6 @@ def test_success_with_sort():
         ),
     ]
     assert len(result) == len(expected)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert result[i].user_id == expected[i].user_id
         assert result[i].match_id == expected[i].match_id

--- a/tests/repositories/user_repository/test_user_repository_delete.py
+++ b/tests/repositories/user_repository/test_user_repository_delete.py
@@ -23,7 +23,7 @@ def test_hit_1_record():
     assert result == 1
     record_on_db = user_repository.find()
     assert len(record_on_db) == len(other_users)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert isinstance(record_on_db[i], User)
         assert record_on_db[i]._id == other_users[i]._id
         assert record_on_db[i].line_user_name == other_users[i].line_user_name
@@ -51,7 +51,7 @@ def test_hit_0_record():
     assert result == 0
     record_on_db = user_repository.find()
     assert len(record_on_db) == len(dummy_users)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert isinstance(record_on_db[i], User)
         assert record_on_db[i].line_user_name == dummy_users[i].line_user_name
         assert record_on_db[i].line_user_id == dummy_users[i].line_user_id

--- a/tests/repositories/user_repository/test_user_repository_delete.py
+++ b/tests/repositories/user_repository/test_user_repository_delete.py
@@ -24,12 +24,12 @@ def test_hit_1_record():
     record_on_db = user_repository.find()
     assert len(record_on_db) == len(other_users)
     for i, _item in enumerate(record_on_db):
-        assert isinstance(record_on_db[i], User)
-        assert record_on_db[i]._id == other_users[i]._id
-        assert record_on_db[i].line_user_name == other_users[i].line_user_name
-        assert record_on_db[i].line_user_id == other_users[i].line_user_id
-        assert record_on_db[i].mode == other_users[i].mode
-        assert record_on_db[i].jantama_name == other_users[i].jantama_name
+        assert isinstance(_item, User)
+        assert _item._id == other_users[i]._id
+        assert _item.line_user_name == other_users[i].line_user_name
+        assert _item.line_user_id == other_users[i].line_user_id
+        assert _item.mode == other_users[i].mode
+        assert _item.jantama_name == other_users[i].jantama_name
 
 
 def test_hit_0_record():
@@ -52,8 +52,8 @@ def test_hit_0_record():
     record_on_db = user_repository.find()
     assert len(record_on_db) == len(dummy_users)
     for i, _item in enumerate(record_on_db):
-        assert isinstance(record_on_db[i], User)
-        assert record_on_db[i].line_user_name == dummy_users[i].line_user_name
-        assert record_on_db[i].line_user_id == dummy_users[i].line_user_id
-        assert record_on_db[i].mode == dummy_users[i].mode
-        assert record_on_db[i].jantama_name == dummy_users[i].jantama_name
+        assert isinstance(_item, User)
+        assert _item.line_user_name == dummy_users[i].line_user_name
+        assert _item.line_user_id == dummy_users[i].line_user_id
+        assert _item.mode == dummy_users[i].mode
+        assert _item.jantama_name == dummy_users[i].jantama_name

--- a/tests/repositories/user_repository/test_user_repository_find.py
+++ b/tests/repositories/user_repository/test_user_repository_find.py
@@ -19,12 +19,12 @@ def test_success_find_records():
     # Assert
     assert len(result) == len(dummy_users)
     for i, _item in enumerate(result):
-        assert isinstance(result[i], User)
-        assert type(result[i]._id) is ObjectId
-        assert result[i].line_user_name == dummy_users[i].line_user_name
-        assert result[i].line_user_id == dummy_users[i].line_user_id
-        assert result[i].mode == dummy_users[i].mode
-        assert result[i].jantama_name == dummy_users[i].jantama_name
+        assert isinstance(_item, User)
+        assert type(_item._id) is ObjectId
+        assert _item.line_user_name == dummy_users[i].line_user_name
+        assert _item.line_user_id == dummy_users[i].line_user_id
+        assert _item.mode == dummy_users[i].mode
+        assert _item.jantama_name == dummy_users[i].jantama_name
 
 
 def test_success_find_0_record():

--- a/tests/repositories/user_repository/test_user_repository_find.py
+++ b/tests/repositories/user_repository/test_user_repository_find.py
@@ -18,7 +18,7 @@ def test_success_find_records():
 
     # Assert
     assert len(result) == len(dummy_users)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert isinstance(result[i], User)
         assert type(result[i]._id) is ObjectId
         assert result[i].line_user_name == dummy_users[i].line_user_name

--- a/tests/repositories/web_user_repository/test_web_user_repository_delete.py
+++ b/tests/repositories/web_user_repository/test_web_user_repository_delete.py
@@ -22,7 +22,7 @@ def test_hit_1_record():
     assert result == 1
     record_on_db = web_user_repository.find()
     assert len(record_on_db) == len(other_users)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert isinstance(record_on_db[i], WebUser)
         assert record_on_db[i].user_code == dummy_web_users[i].user_code
         assert record_on_db[i].name == dummy_web_users[i].name
@@ -50,7 +50,7 @@ def test_hit_0_record():
     assert result == 0
     record_on_db = web_user_repository.find()
     assert len(record_on_db) == len(dummy_web_users)
-    for i in range(len(record_on_db)):
+    for i, _item in enumerate(record_on_db):
         assert isinstance(record_on_db[i], WebUser)
         assert record_on_db[i].user_code == dummy_web_users[i].user_code
         assert record_on_db[i].name == dummy_web_users[i].name

--- a/tests/repositories/web_user_repository/test_web_user_repository_delete.py
+++ b/tests/repositories/web_user_repository/test_web_user_repository_delete.py
@@ -23,12 +23,12 @@ def test_hit_1_record():
     record_on_db = web_user_repository.find()
     assert len(record_on_db) == len(other_users)
     for i, _item in enumerate(record_on_db):
-        assert isinstance(record_on_db[i], WebUser)
-        assert record_on_db[i].user_code == dummy_web_users[i].user_code
-        assert record_on_db[i].name == dummy_web_users[i].name
-        assert record_on_db[i].email == dummy_web_users[i].email
-        assert record_on_db[i].linked_line_user_id == dummy_web_users[i].linked_line_user_id
-        assert record_on_db[i].is_approved_line_user == dummy_web_users[i].is_approved_line_user
+        assert isinstance(_item, WebUser)
+        assert _item.user_code == dummy_web_users[i].user_code
+        assert _item.name == dummy_web_users[i].name
+        assert _item.email == dummy_web_users[i].email
+        assert _item.linked_line_user_id == dummy_web_users[i].linked_line_user_id
+        assert _item.is_approved_line_user == dummy_web_users[i].is_approved_line_user
 
 
 def test_hit_0_record():
@@ -51,9 +51,9 @@ def test_hit_0_record():
     record_on_db = web_user_repository.find()
     assert len(record_on_db) == len(dummy_web_users)
     for i, _item in enumerate(record_on_db):
-        assert isinstance(record_on_db[i], WebUser)
-        assert record_on_db[i].user_code == dummy_web_users[i].user_code
-        assert record_on_db[i].name == dummy_web_users[i].name
-        assert record_on_db[i].email == dummy_web_users[i].email
-        assert record_on_db[i].linked_line_user_id == dummy_web_users[i].linked_line_user_id
-        assert record_on_db[i].is_approved_line_user == dummy_web_users[i].is_approved_line_user
+        assert isinstance(_item, WebUser)
+        assert _item.user_code == dummy_web_users[i].user_code
+        assert _item.name == dummy_web_users[i].name
+        assert _item.email == dummy_web_users[i].email
+        assert _item.linked_line_user_id == dummy_web_users[i].linked_line_user_id
+        assert _item.is_approved_line_user == dummy_web_users[i].is_approved_line_user

--- a/tests/repositories/web_user_repository/test_web_user_repository_find.py
+++ b/tests/repositories/web_user_repository/test_web_user_repository_find.py
@@ -18,7 +18,7 @@ def test_success_find_records():
 
     # Assert
     assert len(result) == len(dummy_web_users)
-    for i in range(len(result)):
+    for i, _item in enumerate(result):
         assert isinstance(result[i], WebUser)
         assert type(result[i]._id) is ObjectId
         assert result[i].user_code == dummy_web_users[i].user_code

--- a/tests/repositories/web_user_repository/test_web_user_repository_find.py
+++ b/tests/repositories/web_user_repository/test_web_user_repository_find.py
@@ -19,14 +19,14 @@ def test_success_find_records():
     # Assert
     assert len(result) == len(dummy_web_users)
     for i, _item in enumerate(result):
-        assert isinstance(result[i], WebUser)
-        assert type(result[i]._id) is ObjectId
-        assert result[i].user_code == dummy_web_users[i].user_code
-        assert result[i].name == dummy_web_users[i].name
-        assert result[i].email == dummy_web_users[i].email
-        assert result[i].linked_line_user_id == dummy_web_users[i].linked_line_user_id
+        assert isinstance(_item, WebUser)
+        assert type(_item._id) is ObjectId
+        assert _item.user_code == dummy_web_users[i].user_code
+        assert _item.name == dummy_web_users[i].name
+        assert _item.email == dummy_web_users[i].email
+        assert _item.linked_line_user_id == dummy_web_users[i].linked_line_user_id
         assert (
-            result[i].is_approved_line_user == dummy_web_users[i].is_approved_line_user
+            _item.is_approved_line_user == dummy_web_users[i].is_approved_line_user
         )
 
 

--- a/tests/scenarios/test_full_game_flow.py
+++ b/tests/scenarios/test_full_game_flow.py
@@ -11,7 +11,6 @@ from repositories import (
     group_repository,
     hanchan_repository,
     match_repository,
-    user_hanchan_repository,
 )
 from use_cases.group_line.add_point_by_text_use_case import AddPointByTextUseCase
 from use_cases.group_line.finish_match_use_case import FinishMatchUseCase
@@ -86,9 +85,9 @@ def test_full_game_flow():
     # グループが wait モードに戻る
     groups = group_repository.find({"line_group_id": GROUP_ID})
     assert groups[0].mode == GroupMode.wait.value
-    # UserHanchan が 4 件作成されている
-    user_hanchans = user_hanchan_repository.find({"hanchan_id": hanchan_id})
-    assert len(user_hanchans) == 4
+    # hanchan.results に 4 件の結果が embedded されている
+    hanchans_with_results = hanchan_repository.find({"_id": hanchan_id})
+    assert len(hanchans_with_results[0].results) == 4
 
     # === Step 5: 対局終了 (グラフ生成は無視) ===
     # match.active_match_id はリセットされているのでグループに再設定して確認

--- a/tests/use_cases/common_line/test__reply_rank_histogram_use_case.py
+++ b/tests/use_cases/common_line/test__reply_rank_histogram_use_case.py
@@ -12,12 +12,11 @@ from domain_model.entities.group import Group, GroupMode
 from domain_model.entities.hanchan import Hanchan
 from domain_model.entities.match import Match
 from domain_model.entities.user import User, UserMode
-from domain_model.entities.user_hanchan import UserHanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
 from repositories import (
     group_repository,
     hanchan_repository,
     match_repository,
-    user_hanchan_repository,
     user_repository,
 )
 from use_cases.common_line.reply_rank_histogram_use_case import (
@@ -74,6 +73,13 @@ dummy_match = Match(
     _id=1,
 )
 
+_results_per_hanchan = [
+    UserHanchanResult(line_user_id=dummy_users[0].line_user_id, point=40000, rank=1),
+    UserHanchanResult(line_user_id=dummy_users[1].line_user_id, point=30000, rank=2),
+    UserHanchanResult(line_user_id=dummy_users[2].line_user_id, point=20000, rank=3),
+    UserHanchanResult(line_user_id=dummy_users[3].line_user_id, point=10000, rank=4),
+]
+
 dummy_archived_hanchans = [
     Hanchan(
         line_group_id=dummy_group.line_group_id,
@@ -89,6 +95,7 @@ dummy_archived_hanchans = [
             dummy_users[2].line_user_id: -20,
             dummy_users[3].line_user_id: -40,
         },
+        results=_results_per_hanchan,
         match_id=1,
         _id=1,
     ),
@@ -106,59 +113,9 @@ dummy_archived_hanchans = [
             dummy_users[2].line_user_id: -20,
             dummy_users[3].line_user_id: -40,
         },
+        results=_results_per_hanchan,
         match_id=1,
         _id=2,
-    ),
-]
-
-dummy_user_hanchans = [
-    UserHanchan(
-        line_user_id=dummy_users[0].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=40000,
-        rank=1,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[1].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=30000,
-        rank=2,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[2].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=20000,
-        rank=3,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[3].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=10000,
-        rank=4,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[0].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=40000,
-        rank=1,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[1].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=30000,
-        rank=2,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[2].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=20000,
-        rank=3,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[3].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=10000,
-        rank=4,
     ),
 ]
 
@@ -220,8 +177,6 @@ def test_success(mocker):
     for dummy_archived_hanchan in dummy_archived_hanchans:
         hanchan_repository.create(dummy_archived_hanchan)
     match_repository.create(dummy_match)
-    for dummy_user_hanchan in dummy_user_hanchans:
-        user_hanchan_repository.create(dummy_user_hanchan)
 
     # Act
     use_case.execute()
@@ -266,8 +221,6 @@ def test_success_with_range(mocker, case2):
     for dummy_archived_hanchan in dummy_archived_hanchans:
         hanchan_repository.create(dummy_archived_hanchan)
     match_repository.create(dummy_match)
-    for dummy_user_hanchan in dummy_user_hanchans:
-        user_hanchan_repository.create(dummy_user_hanchan)
 
     # Act
     use_case.execute()
@@ -346,8 +299,6 @@ def test_success_fail_savefig(mocker):
     for dummy_archived_hanchan in dummy_archived_hanchans:
         hanchan_repository.create(dummy_archived_hanchan)
     match_repository.create(dummy_match)
-    for dummy_user_hanchan in dummy_user_hanchans:
-        user_hanchan_repository.create(dummy_user_hanchan)
 
     # Act
     use_case.execute()

--- a/tests/use_cases/common_line/test__reply_rank_history_use_case.py
+++ b/tests/use_cases/common_line/test__reply_rank_history_use_case.py
@@ -12,12 +12,11 @@ from domain_model.entities.group import Group, GroupMode
 from domain_model.entities.hanchan import Hanchan
 from domain_model.entities.match import Match
 from domain_model.entities.user import User, UserMode
-from domain_model.entities.user_hanchan import UserHanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
 from repositories import (
     group_repository,
     hanchan_repository,
     match_repository,
-    user_hanchan_repository,
     user_repository,
 )
 from use_cases.common_line.reply_rank_history_use_case import ReplyRankHistoryUseCase
@@ -72,6 +71,13 @@ dummy_match = Match(
     _id=1,
 )
 
+_results_per_hanchan = [
+    UserHanchanResult(line_user_id=dummy_users[0].line_user_id, point=40000, rank=1),
+    UserHanchanResult(line_user_id=dummy_users[1].line_user_id, point=30000, rank=2),
+    UserHanchanResult(line_user_id=dummy_users[2].line_user_id, point=20000, rank=3),
+    UserHanchanResult(line_user_id=dummy_users[3].line_user_id, point=10000, rank=4),
+]
+
 dummy_archived_hanchans = [
     Hanchan(
         line_group_id=dummy_group.line_group_id,
@@ -87,6 +93,7 @@ dummy_archived_hanchans = [
             dummy_users[2].line_user_id: -20,
             dummy_users[3].line_user_id: -40,
         },
+        results=_results_per_hanchan,
         match_id=1,
         _id=1,
     ),
@@ -104,59 +111,9 @@ dummy_archived_hanchans = [
             dummy_users[2].line_user_id: -20,
             dummy_users[3].line_user_id: -40,
         },
+        results=_results_per_hanchan,
         match_id=1,
         _id=2,
-    ),
-]
-
-dummy_user_hanchans = [
-    UserHanchan(
-        line_user_id=dummy_users[0].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=40000,
-        rank=1,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[1].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=30000,
-        rank=2,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[2].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=20000,
-        rank=3,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[3].line_user_id,
-        hanchan_id=dummy_archived_hanchans[0]._id,
-        point=10000,
-        rank=4,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[0].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=40000,
-        rank=1,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[1].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=30000,
-        rank=2,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[2].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=20000,
-        rank=3,
-    ),
-    UserHanchan(
-        line_user_id=dummy_users[3].line_user_id,
-        hanchan_id=dummy_archived_hanchans[1]._id,
-        point=10000,
-        rank=4,
     ),
 ]
 
@@ -218,8 +175,6 @@ def test_success(mocker):
     for dummy_archived_hanchan in dummy_archived_hanchans:
         hanchan_repository.create(dummy_archived_hanchan)
     match_repository.create(dummy_match)
-    for dummy_user_hanchan in dummy_user_hanchans:
-        user_hanchan_repository.create(dummy_user_hanchan)
 
     # Act
     use_case.execute()
@@ -243,7 +198,7 @@ def test_success_with_range(mocker, case2):
     # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
     # 想定出力: reply_service.texts の件数が 1 件 / reply_service.texts[0].text が case2[1] である / reply_service.images の件数が 2 件
     # reply_service: images, texts
-    # DB操作: group_repository.create(dummy_group); user_repository.create(dummy_user); hanchan_repository.create(dummy_archived_hanchan); match_repository.create(dummy_match); user_hanchan_repository.create(dummy_user_hanchan)
+    # DB操作: group_repository.create(dummy_group); user_repository.create(dummy_user); hanchan_repository.create(dummy_archived_hanchan); match_repository.create(dummy_match)
     # Arrange
     fig, ax = plt.subplots()
     mocker.patch.object(
@@ -264,8 +219,6 @@ def test_success_with_range(mocker, case2):
     for dummy_archived_hanchan in dummy_archived_hanchans:
         hanchan_repository.create(dummy_archived_hanchan)
     match_repository.create(dummy_match)
-    for dummy_user_hanchan in dummy_user_hanchans:
-        user_hanchan_repository.create(dummy_user_hanchan)
 
     # Act
     use_case.execute()
@@ -344,8 +297,6 @@ def test_success_fail_savefig(mocker):
     for dummy_archived_hanchan in dummy_archived_hanchans:
         hanchan_repository.create(dummy_archived_hanchan)
     match_repository.create(dummy_match)
-    for dummy_user_hanchan in dummy_user_hanchans:
-        user_hanchan_repository.create(dummy_user_hanchan)
 
     # Act
     use_case.execute()

--- a/tests/use_cases/group_line/test__finish_input_chip_use_case.py
+++ b/tests/use_cases/group_line/test__finish_input_chip_use_case.py
@@ -3,14 +3,13 @@ from application_service import (
     request_info_service,
 )
 from domain_model.entities.group import Group, GroupMode
-from domain_model.entities.group_setting import GroupSetting
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 from domain_model.entities.hanchan import Hanchan
 from domain_model.entities.match import Match
 from domain_model.entities.user import User, UserMode
 from line_models.event import Event
 from repositories import (
     group_repository,
-    group_setting_repository,
     hanchan_repository,
     match_repository,
     user_repository,
@@ -62,10 +61,7 @@ dummy_group = Group(
     _id=1,
 )
 
-dummy_group_setting = GroupSetting(
-    line_group_id="G0123456789abcdefghijklmnopqrstu1",
-    chip_rate=50,
-)
+dummy_embedded_settings = EmbeddedGroupSettings(chip_rate=50)
 
 dummy_match = Match(
     line_group_id=dummy_group.line_group_id,
@@ -177,7 +173,6 @@ def test_fail_no_group():
 
     use_case = FinishInputChipUseCase()
     request_info_service.req_line_group_id = dummy_group.line_group_id
-    group_setting_repository.create(dummy_group_setting)
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
     match_repository.create(dummy_match)
@@ -208,7 +203,7 @@ def test_fail_no_match():
     use_case = FinishInputChipUseCase()
     request_info_service.req_line_group_id = dummy_group.line_group_id
     group_repository.create(dummy_group)
-    group_setting_repository.create(dummy_group_setting)
+    group_repository.update_settings(dummy_group.line_group_id, dummy_embedded_settings)
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
     for dummy_hanchan in dummy_hanchans:
@@ -238,7 +233,7 @@ def test_fail_chip_sum_mismatch():
     use_case = FinishInputChipUseCase()
     request_info_service.req_line_group_id = dummy_group.line_group_id
     group_repository.create(dummy_group)
-    group_setting_repository.create(dummy_group_setting)
+    group_repository.update_settings(dummy_group.line_group_id, dummy_embedded_settings)
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
     match_repository.create(
@@ -281,7 +276,7 @@ def test_success():
     use_case = FinishInputChipUseCase()
     request_info_service.req_line_group_id = dummy_group.line_group_id
     group_repository.create(dummy_group)
-    group_setting_repository.create(dummy_group_setting)
+    group_repository.update_settings(dummy_group.line_group_id, dummy_embedded_settings)
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
     match_repository.create(dummy_match)

--- a/tests/use_cases/group_line/test__finish_match_use_case.py
+++ b/tests/use_cases/group_line/test__finish_match_use_case.py
@@ -3,13 +3,12 @@ from application_service import (
     request_info_service,
 )
 from domain_model.entities.group import Group, GroupMode
-from domain_model.entities.group_setting import GroupSetting
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 from domain_model.entities.hanchan import Hanchan
 from domain_model.entities.match import Match
 from domain_model.entities.user import User, UserMode
 from repositories import (
     group_repository,
-    group_setting_repository,
     hanchan_repository,
     match_repository,
     user_repository,
@@ -203,11 +202,9 @@ def test_success():
             _id=1,
         ),
     )
-    group_setting_repository.create(
-        GroupSetting(
-            line_group_id="G0123456789abcdefghijklmnopqrstu1",
-            rate=5,
-        ),
+    group_repository.update_settings(
+        "G0123456789abcdefghijklmnopqrstu1",
+        EmbeddedGroupSettings(rate=5),
     )
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
@@ -269,11 +266,9 @@ def test_success_with_chip_init():
     use_case = FinishMatchUseCase()
     request_info_service.req_line_group_id = dummy_group.line_group_id
     group_repository.create(dummy_group)
-    group_setting_repository.create(
-        GroupSetting(
-            line_group_id="G0123456789abcdefghijklmnopqrstu1",
-            chip_rate=50,
-        ),
+    group_repository.update_settings(
+        "G0123456789abcdefghijklmnopqrstu1",
+        EmbeddedGroupSettings(chip_rate=50),
     )
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
@@ -314,11 +309,10 @@ def test_success_with_chip():
             _id=1,
         ),
     )
-    dummy_group_setting = GroupSetting(
-        line_group_id="G0123456789abcdefghijklmnopqrstu1",
-        chip_rate=50,
+    group_repository.update_settings(
+        "G0123456789abcdefghijklmnopqrstu1",
+        EmbeddedGroupSettings(chip_rate=50),
     )
-    group_setting_repository.create(dummy_group_setting)
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
     match_repository.create(

--- a/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
+++ b/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
@@ -7,23 +7,15 @@ from application_service import (
     reply_service,
     request_info_service,
 )
-from domain_model.entities.group_setting import GroupSetting
+from domain_model.entities.group import Group, GroupMode
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 from line_models.event import Event
-from repositories import group_setting_repository
+from repositories import group_repository
 from use_cases.group_line.reply_group_settings_menu_use_case import (
     ReplyGroupSettingsMenuUseCase,
 )
 
-dummy_group_settings = GroupSetting(
-    line_group_id="G0123456789abcdefghijklmnopqrstu1",
-    rate=3,
-    ranking_prize=[20, 10, -10, -20],
-    chip_rate=1,
-    tobi_prize=10,
-    num_of_players=4,
-    rounding_method=0,
-    _id=1,
-)
+dummy_line_group_id = "G0123456789abcdefghijklmnopqrstu1"
 
 dummy_event = Event(
     type="message",
@@ -41,11 +33,15 @@ def test_execute():
     # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
     # 想定出力: reply_service.texts の件数が 1 件 / ( / reply_service.buttons の件数が 1 件 / reply_service.buttons[0] が TemplateSendMessage 型
     # reply_service: buttons, texts
-    # DB操作: group_setting_repository.create(dummy_group_settings)
+    # DB操作: group_repository.create; group_repository.update_settings
     # Arrange
     request_info_service.set_req_info(event=dummy_event)
     use_case = ReplyGroupSettingsMenuUseCase()
-    group_setting_repository.create(dummy_group_settings)
+    group_repository.create(Group(line_group_id=dummy_line_group_id, mode=GroupMode.wait.value))
+    group_repository.update_settings(
+        dummy_line_group_id,
+        EmbeddedGroupSettings(rate=3, ranking_prize=[20, 10, -10, -20], chip_rate=1, tobi_prize=10, num_of_players=4, rounding_method=0),
+    )
 
     # Act
     use_case.execute("")

--- a/tests/use_cases/group_line/test__reply_ranking_table_use_case.py
+++ b/tests/use_cases/group_line/test__reply_ranking_table_use_case.py
@@ -84,7 +84,7 @@ def test_success_fail_savefig(mocker):
     mock_image.open.return_value = mock_img
     mock_image.alpha_composite.return_value = mock_img
     mocker.patch(
-        "use_cases.group_line.reply_ranking_table_use_case.Image",
+        "application_service.ranking_table_image_builder.Image",
         mock_image,
     )
 
@@ -93,11 +93,11 @@ def test_success_fail_savefig(mocker):
     mock_image_draw = MagicMock()
     mock_image_draw.Draw.return_value = mock_draw
     mocker.patch(
-        "use_cases.group_line.reply_ranking_table_use_case.ImageDraw",
+        "application_service.ranking_table_image_builder.ImageDraw",
         mock_image_draw,
     )
     mocker.patch(
-        "use_cases.group_line.reply_ranking_table_use_case.ImageFont",
+        "application_service.ranking_table_image_builder.ImageFont",
         MagicMock(),
     )
 

--- a/tests/use_cases/group_line/test__submit_hanchan_use_case.py
+++ b/tests/use_cases/group_line/test__submit_hanchan_use_case.py
@@ -1,7 +1,5 @@
 from copy import deepcopy
 
-from pymongo import ASCENDING
-
 from application_service import (
     calculate_service,
     reply_service,
@@ -11,13 +9,12 @@ from domain_model.entities.group import Group, GroupMode
 from domain_model.entities.hanchan import Hanchan
 from domain_model.entities.match import Match
 from domain_model.entities.user import User, UserMode
-from domain_model.entities.user_hanchan import UserHanchan
+from domain_model.entities.user_hanchan import UserHanchanResult
 from domain_model.entities.user_match import UserMatch
 from repositories import (
     group_repository,
     hanchan_repository,
     match_repository,
-    user_hanchan_repository,
     user_match_repository,
     user_repository,
 )
@@ -234,43 +231,19 @@ def test_success():
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu3"] == -20
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu4"] == -40
 
-    expected_uhs = [
-        UserHanchan(
-            line_user_id="U0123456789abcdefghijklmnopqrstu1",
-            hanchan_id=1,
-            point=40010,
-            rank=1,
-            yakuman_count=0,
-        ),
-        UserHanchan(
-            line_user_id="U0123456789abcdefghijklmnopqrstu2",
-            hanchan_id=1,
-            point=30000,
-            rank=2,
-            yakuman_count=0,
-        ),
-        UserHanchan(
-            line_user_id="U0123456789abcdefghijklmnopqrstu3",
-            hanchan_id=1,
-            point=20000,
-            rank=3,
-            yakuman_count=0,
-        ),
-        UserHanchan(
-            line_user_id="U0123456789abcdefghijklmnopqrstu4",
-            hanchan_id=1,
-            point=10000,
-            rank=4,
-            yakuman_count=0,
-        ),
+    expected_results = [
+        UserHanchanResult(line_user_id="U0123456789abcdefghijklmnopqrstu1", point=40010, rank=1),
+        UserHanchanResult(line_user_id="U0123456789abcdefghijklmnopqrstu2", point=30000, rank=2),
+        UserHanchanResult(line_user_id="U0123456789abcdefghijklmnopqrstu3", point=20000, rank=3),
+        UserHanchanResult(line_user_id="U0123456789abcdefghijklmnopqrstu4", point=10000, rank=4),
     ]
-    uhs = user_hanchan_repository.find(sort=[("rank", ASCENDING)])
-    for i in range(len(uhs)):
-        assert uhs[i].line_user_id == expected_uhs[i].line_user_id
-        assert uhs[i].hanchan_id == expected_uhs[i].hanchan_id
-        assert uhs[i].point == expected_uhs[i].point
-        assert uhs[i].rank == expected_uhs[i].rank
-        assert uhs[i].yakuman_count == expected_uhs[i].yakuman_count
+    active = hanchan_repository.find({"_id": dummy_active_hanchan._id})[0]
+    results = sorted(active.results, key=lambda r: r.rank)
+    for result, expected in zip(results, expected_results):
+        assert result.line_user_id == expected.line_user_id
+        assert result.point == expected.point
+        assert result.rank == expected.rank
+        assert result.yakuman_count == expected.yakuman_count
 
     reply_service.reset()
 

--- a/tests/use_cases/group_line/test__update_group_settings_use_case.py
+++ b/tests/use_cases/group_line/test__update_group_settings_use_case.py
@@ -4,24 +4,26 @@ from application_service import (
     reply_service,
     request_info_service,
 )
-from domain_model.entities.group_setting import GroupSetting
+from domain_model.entities.group import Group, GroupMode
+from domain_model.entities.group_setting import EmbeddedGroupSettings
 from line_models.event import Event
-from repositories import group_setting_repository
+from repositories import group_repository
 from use_cases.group_line.update_group_settings_use_case import (
     UpdateGroupSettingsUseCase,
 )
+
+dummy_line_group_id = "G0123456789abcdefghijklmnopqrstu1"
 
 dummy_event = Event(
     type="message",
     source_type="group",
     user_id="U0123456789abcdefghijklmnopqrstu1",
-    group_id="G0123456789abcdefghijklmnopqrstu1",
+    group_id=dummy_line_group_id,
     message_type="text",
     text="_input",
 )
 
-dummy_setting = GroupSetting(
-    line_group_id="G0123456789abcdefghijklmnopqrstu1",
+dummy_initial_settings = EmbeddedGroupSettings(
     rate=0,
     ranking_prize=[20, 10, -10, -20],
     chip_rate=0,
@@ -31,206 +33,155 @@ dummy_setting = GroupSetting(
 )
 
 
-def test_execute_rate():
-    # 目的: test_execute_rate の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / reply_service.texts[0].text が "[レート]を[点3]に変更しました。" である / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 3 である / settings[0].ranking_prize が [20, 10, -10, -20] である / settings[0].chip_rate が 0 である / settings[0].tobi_prize が 10 である / settings[0].num_of_players が 4 である / settings[0].rounding_method が 0 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
-    request_info_service.set_req_info(event=dummy_event)
-    use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
+def _setup():
+    """グループと初期設定を作成する"""
+    group_repository.create(Group(line_group_id=dummy_line_group_id, mode=GroupMode.wait.value))
+    group_repository.update_settings(dummy_line_group_id, dummy_initial_settings)
 
-    # Act
+
+def _get_settings():
+    return group_repository.find({"line_group_id": dummy_line_group_id})[0].settings
+
+
+def test_execute_rate():
+    # 目的: レートを変更したとき settings.rate が更新されること
+    # 入力: rate=3
+    # 想定出力: settings.rate が 3 / 他フィールドは変わらない
+    request_info_service.set_req_info(event=dummy_event)
+    _setup()
+    use_case = UpdateGroupSettingsUseCase()
+
     use_case.execute("レート", "3")
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert reply_service.texts[0].text == "[レート]を[点3]に変更しました。"
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 3
-    assert settings[0].ranking_prize == [20, 10, -10, -20]
-    assert settings[0].chip_rate == 0
-    assert settings[0].tobi_prize == 10
-    assert settings[0].num_of_players == 4
-    assert settings[0].rounding_method == 0
+    s = _get_settings()
+    assert s.rate == 3
+    assert s.ranking_prize == [20, 10, -10, -20]
+    assert s.chip_rate == 0
+    assert s.tobi_prize == 10
+    assert s.num_of_players == 4
+    assert s.rounding_method == 0
 
 
 def test_execute_ranking_prize():
-    # 目的: test_execute_ranking_prize の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / ( / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 0 である / settings[0].ranking_prize が [30, 10, -10, -30] である / settings[0].chip_rate が 0 である / settings[0].tobi_prize が 10 である / settings[0].num_of_players が 4 である / settings[0].rounding_method が 0 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
+    # 目的: 順位点を変更したとき settings.ranking_prize が更新されること
     request_info_service.set_req_info(event=dummy_event)
+    _setup()
     use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
 
-    # Act
     use_case.execute("順位点", "30,10,-10,-30")
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
         == "[順位点]を[1着 30/2着 10/3着 -10/4着 -30]に変更しました。"
     )
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 0
-    assert settings[0].ranking_prize == [30, 10, -10, -30]
-    assert settings[0].chip_rate == 0
-    assert settings[0].tobi_prize == 10
-    assert settings[0].num_of_players == 4
-    assert settings[0].rounding_method == 0
+    s = _get_settings()
+    assert s.rate == 0
+    assert s.ranking_prize == [30, 10, -10, -30]
+    assert s.chip_rate == 0
+    assert s.tobi_prize == 10
+    assert s.num_of_players == 4
+    assert s.rounding_method == 0
 
 
 def test_execute_chip_rate():
-    # 目的: test_execute_chip_rate の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / reply_service.texts[0].text が "[チップ]を[1枚100円]に変更しました。" である / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 0 である / settings[0].ranking_prize が [20, 10, -10, -20] である / settings[0].chip_rate が 100 である / settings[0].tobi_prize が 10 である / settings[0].num_of_players が 4 である / settings[0].rounding_method が 0 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
+    # 目的: チップを変更したとき settings.chip_rate が更新されること
     request_info_service.set_req_info(event=dummy_event)
+    _setup()
     use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
 
-    # Act
     use_case.execute("チップ", "100")
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert reply_service.texts[0].text == "[チップ]を[1枚100円]に変更しました。"
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 0
-    assert settings[0].ranking_prize == [20, 10, -10, -20]
-    assert settings[0].chip_rate == 100
-    assert settings[0].tobi_prize == 10
-    assert settings[0].num_of_players == 4
-    assert settings[0].rounding_method == 0
+    s = _get_settings()
+    assert s.rate == 0
+    assert s.ranking_prize == [20, 10, -10, -20]
+    assert s.chip_rate == 100
+    assert s.tobi_prize == 10
+    assert s.num_of_players == 4
+    assert s.rounding_method == 0
 
 
 def test_execute_tobi_prize():
-    # 目的: test_execute_tobi_prize の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / reply_service.texts[0].text が "[飛び賞]を[0]に変更しました。" である / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 0 である / settings[0].ranking_prize が [20, 10, -10, -20] である / settings[0].chip_rate が 0 である / settings[0].tobi_prize が 0 である / settings[0].num_of_players が 4 である / settings[0].rounding_method が 0 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
+    # 目的: 飛び賞を変更したとき settings.tobi_prize が更新されること
     request_info_service.set_req_info(event=dummy_event)
+    _setup()
     use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
 
-    # Act
     use_case.execute("飛び賞", "0")
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert reply_service.texts[0].text == "[飛び賞]を[0]に変更しました。"
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 0
-    assert settings[0].ranking_prize == [20, 10, -10, -20]
-    assert settings[0].chip_rate == 0
-    assert settings[0].tobi_prize == 0
-    assert settings[0].num_of_players == 4
-    assert settings[0].rounding_method == 0
+    s = _get_settings()
+    assert s.rate == 0
+    assert s.ranking_prize == [20, 10, -10, -20]
+    assert s.chip_rate == 0
+    assert s.tobi_prize == 0
+    assert s.num_of_players == 4
+    assert s.rounding_method == 0
 
 
 def test_execute_num_of_players():
-    # 目的: test_execute_num_of_players の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / reply_service.texts[0].text が "[人数]を[3人]に変更しました。" である / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 0 である / settings[0].ranking_prize が [20, 10, -10, -20] である / settings[0].chip_rate が 0 である / settings[0].tobi_prize が 10 である / settings[0].num_of_players が 3 である / settings[0].rounding_method が 0 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
+    # 目的: 人数を変更したとき settings.num_of_players が更新されること
     request_info_service.set_req_info(event=dummy_event)
+    _setup()
     use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
 
-    # Act
     use_case.execute("人数", "3")
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert reply_service.texts[0].text == "[人数]を[3人]に変更しました。"
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 0
-    assert settings[0].ranking_prize == [20, 10, -10, -20]
-    assert settings[0].chip_rate == 0
-    assert settings[0].tobi_prize == 10
-    assert settings[0].num_of_players == 3
-    assert settings[0].rounding_method == 0
+    s = _get_settings()
+    assert s.rate == 0
+    assert s.ranking_prize == [20, 10, -10, -20]
+    assert s.chip_rate == 0
+    assert s.tobi_prize == 10
+    assert s.num_of_players == 3
+    assert s.rounding_method == 0
 
 
 def test_execute_rounding_method():
-    # 目的: test_execute_rounding_method の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / reply_service.texts[0].text が "[端数計算方法]を[五捨六入]に変更しました。" である / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 0 である / settings[0].ranking_prize が [20, 10, -10, -20] である / settings[0].chip_rate が 0 である / settings[0].tobi_prize が 10 である / settings[0].num_of_players が 4 である / settings[0].rounding_method が 1 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
+    # 目的: 端数計算方法を変更したとき settings.rounding_method が更新されること
     request_info_service.set_req_info(event=dummy_event)
+    _setup()
     use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
 
-    # Act
     use_case.execute("端数計算方法", "1")
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert reply_service.texts[0].text == "[端数計算方法]を[五捨六入]に変更しました。"
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 0
-    assert settings[0].ranking_prize == [20, 10, -10, -20]
-    assert settings[0].chip_rate == 0
-    assert settings[0].tobi_prize == 10
-    assert settings[0].num_of_players == 4
-    assert settings[0].rounding_method == 1
+    s = _get_settings()
+    assert s.rate == 0
+    assert s.ranking_prize == [20, 10, -10, -20]
+    assert s.chip_rate == 0
+    assert s.tobi_prize == 10
+    assert s.num_of_players == 4
+    assert s.rounding_method == 1
 
 
 def test_execute_invalid_key():
-    # 目的: test_execute_invalid_key の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / ( / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 0 である / settings[0].ranking_prize が [20, 10, -10, -20] である / settings[0].chip_rate が 0 である / settings[0].tobi_prize が 10 である / settings[0].num_of_players が 4 である / settings[0].rounding_method が 0 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
+    # 目的: 未知の項目を渡したとき適切なエラーメッセージが返ること
     request_info_service.set_req_info(event=dummy_event)
+    _setup()
     use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
 
-    # Act
     use_case.execute("dummy", "1")
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
         == "項目[dummy]は未知の項目のため、[dummy]を[1]に変更できません"
     )
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 0
-    assert settings[0].ranking_prize == [20, 10, -10, -20]
-    assert settings[0].chip_rate == 0
-    assert settings[0].tobi_prize == 10
-    assert settings[0].num_of_players == 4
-    assert settings[0].rounding_method == 0
+    s = _get_settings()
+    assert s.rate == 0
+    assert s.ranking_prize == [20, 10, -10, -20]
+    assert s.chip_rate == 0
+    assert s.tobi_prize == 10
+    assert s.num_of_players == 4
+    assert s.rounding_method == 0
 
 
 @pytest.fixture(
@@ -249,28 +200,19 @@ def text_case1(request):
 
 
 def test_execute_invalid_value(text_case1):
-    # 目的: test_execute_invalid_value の挙動を検証する。
-    # 入力: text_case1
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 1 件 / reply_service.texts[0].text が text_case1[2] である / settings[0].line_group_id が "G0123456789abcdefghijklmnopqrstu1" である / settings[0].rate が 0 である / settings[0].ranking_prize が [20, 10, -10, -20] である / settings[0].chip_rate が 0 である / settings[0].tobi_prize が 10 である / settings[0].num_of_players が 4 である / settings[0].rounding_method が 0 である
-    # reply_service: texts
-    # DB操作: group_setting_repository.create(dummy_setting); settings = group_setting_repository.find()
-    # Arrange
+    # 目的: 不正な値を渡したとき変更不可メッセージが返ること
     request_info_service.set_req_info(event=dummy_event)
+    _setup()
     use_case = UpdateGroupSettingsUseCase()
-    group_setting_repository.create(dummy_setting)
 
-    # Act
     use_case.execute(text_case1[0], text_case1[1])
 
-    # Assert
     assert len(reply_service.texts) == 1
     assert reply_service.texts[0].text == text_case1[2]
-    settings = group_setting_repository.find()
-    assert settings[0].line_group_id == "G0123456789abcdefghijklmnopqrstu1"
-    assert settings[0].rate == 0
-    assert settings[0].ranking_prize == [20, 10, -10, -20]
-    assert settings[0].chip_rate == 0
-    assert settings[0].tobi_prize == 10
-    assert settings[0].num_of_players == 4
-    assert settings[0].rounding_method == 0
+    s = _get_settings()
+    assert s.rate == 0
+    assert s.ranking_prize == [20, 10, -10, -20]
+    assert s.chip_rate == 0
+    assert s.tobi_prize == 10
+    assert s.num_of_players == 4
+    assert s.rounding_method == 0

--- a/tests/use_cases/test_create_dummy_use_case.py
+++ b/tests/use_cases/test_create_dummy_use_case.py
@@ -1,6 +1,5 @@
 from repositories import (
     group_repository,
-    group_setting_repository,
     hanchan_repository,
     match_repository,
     user_repository,
@@ -13,9 +12,9 @@ def test_create_dummy_use_case():
     # 目的: test_create_dummy_use_case の挙動を検証する。
     # 入力: なし
     # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: users の件数が 10 件 / web_users の件数が 4 件 / groups の件数が 5 件 / groups_settings の件数が 3 件 / hanchans の件数が 2 件 / matches の件数が 2 件
+    # 想定出力: users の件数が 10 件 / web_users の件数が 4 件 / groups の件数が 5 件 / hanchans の件数が 2 件 / matches の件数が 2 件
     # reply_service: なし
-    # DB操作: users = user_repository.find(); web_users = web_user_repository.find(); groups = group_repository.find(); groups_settings = group_setting_repository.find(); matches = match_repository.find(); hanchans = hanchan_repository.find()
+    # DB操作: users = user_repository.find(); web_users = web_user_repository.find(); groups = group_repository.find(); matches = match_repository.find(); hanchans = hanchan_repository.find()
     # Act
     CreateDummyUseCase().execute()
 
@@ -23,13 +22,11 @@ def test_create_dummy_use_case():
     users = user_repository.find()
     web_users = web_user_repository.find()
     groups = group_repository.find()
-    groups_settings = group_setting_repository.find()
     matches = match_repository.find()
     hanchans = hanchan_repository.find()
 
     assert len(users) == 10
     assert len(web_users) == 4
     assert len(groups) == 5
-    assert len(groups_settings) == 3
     assert len(hanchans) == 2
     assert len(matches) == 2

--- a/tests/use_cases/web/test__delete_configs_for_web_use_case.py
+++ b/tests/use_cases/web/test__delete_configs_for_web_use_case.py
@@ -1,43 +1,44 @@
-from domain_model.entities.group_setting import GroupSetting
-from repositories import group_setting_repository
+from domain_model.entities.group import Group, GroupMode
+from domain_model.entities.group_setting import EmbeddedGroupSettings
+from repositories import group_repository
 from use_cases.web.delete_configs_for_web_use_case import DeleteConfigsForWebUseCase
 
 
-def test_execute_deletes_configs_by_ids():
-    # 目的: test_execute_deletes_configs_by_ids の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: remaining の件数が 1 件 / remaining[0].line_group_id が "G2" である
-    # reply_service: なし
-    # DB操作: c1 = group_setting_repository.create(GroupSetting(line_group_id="G1")); c2 = group_setting_repository.create(GroupSetting(line_group_id="G2")); remaining = group_setting_repository.find()
+def test_execute_clears_settings_by_line_group_ids():
+    # 目的: 指定した line_group_id の settings が None にリセットされること
+    # 入力: G1, G2 グループを作成し両方に settings を設定
+    # 想定出力: G1 の settings は None / G2 の settings は残る
     # Arrange
-    c1 = group_setting_repository.create(GroupSetting(line_group_id="G1"))
-    group_setting_repository.create(GroupSetting(line_group_id="G2"))
+    settings = EmbeddedGroupSettings(rate=5)
+    group_repository.create(Group(line_group_id="G1", mode=GroupMode.wait.value))
+    group_repository.create(Group(line_group_id="G2", mode=GroupMode.wait.value))
+    group_repository.update({"line_group_id": "G1"}, {"settings": settings.to_dict()})
+    group_repository.update({"line_group_id": "G2"}, {"settings": settings.to_dict()})
     use_case = DeleteConfigsForWebUseCase()
 
     # Act
-    use_case.execute([c1._id])
+    use_case.execute(["G1"])
 
     # Assert
-    remaining = group_setting_repository.find()
-    assert len(remaining) == 1
-    assert remaining[0].line_group_id == "G2"
+    g1 = group_repository.find({"line_group_id": "G1"})[0]
+    g2 = group_repository.find({"line_group_id": "G2"})[0]
+    assert g1.settings is None
+    assert g2.settings is not None
 
 
 def test_execute_with_empty_ids_does_nothing():
-    # 目的: test_execute_with_empty_ids_does_nothing の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: remaining の件数が 1 件
-    # reply_service: なし
-    # DB操作: group_setting_repository.create(GroupSetting(line_group_id="G1")); remaining = group_setting_repository.find()
+    # 目的: 空リストを渡した場合に設定が変わらないこと
+    # 入力: G1 グループに settings を設定
+    # 想定出力: G1 の settings は変わらない
     # Arrange
-    group_setting_repository.create(GroupSetting(line_group_id="G1"))
+    settings = EmbeddedGroupSettings(rate=5)
+    group_repository.create(Group(line_group_id="G1", mode=GroupMode.wait.value))
+    group_repository.update({"line_group_id": "G1"}, {"settings": settings.to_dict()})
     use_case = DeleteConfigsForWebUseCase()
 
     # Act
     use_case.execute([])
 
     # Assert
-    remaining = group_setting_repository.find()
-    assert len(remaining) == 1
+    g1 = group_repository.find({"line_group_id": "G1"})[0]
+    assert g1.settings is not None

--- a/tests/use_cases/web/test__get_config_for_web_use_case.py
+++ b/tests/use_cases/web/test__get_config_for_web_use_case.py
@@ -1,5 +1,4 @@
 from domain_model.entities.group import Group, GroupMode
-from domain_model.entities.group_setting import EmbeddedGroupSettings
 from repositories import group_repository
 from use_cases.web.get_config_for_web_use_case import GetConfigForWebUseCase
 
@@ -7,7 +6,7 @@ from use_cases.web.get_config_for_web_use_case import GetConfigForWebUseCase
 def test_execute_returns_config_by_line_group_id():
     # 目的: line_group_id でグループの設定を取得できること
     # 入力: G1 グループを作成
-    # 想定出力: config is not None / EmbeddedGroupSettings インスタンスである
+    # 想定出力: config is not None / dict である / _id == "G1"
     # Arrange
     group_repository.create(Group(line_group_id="G1", mode=GroupMode.wait.value))
     use_case = GetConfigForWebUseCase()
@@ -17,7 +16,8 @@ def test_execute_returns_config_by_line_group_id():
 
     # Assert
     assert config is not None
-    assert isinstance(config, EmbeddedGroupSettings)
+    assert isinstance(config, dict)
+    assert config["_id"] == "G1"
 
 
 def test_execute_returns_none_for_missing_line_group_id():

--- a/tests/use_cases/web/test__get_config_for_web_use_case.py
+++ b/tests/use_cases/web/test__get_config_for_web_use_case.py
@@ -1,39 +1,34 @@
-from domain_model.entities.group_setting import GroupSetting
-from repositories import group_setting_repository
+from domain_model.entities.group import Group, GroupMode
+from domain_model.entities.group_setting import EmbeddedGroupSettings
+from repositories import group_repository
 from use_cases.web.get_config_for_web_use_case import GetConfigForWebUseCase
 
 
-def test_execute_returns_config_by_id():
-    # 目的: test_execute_returns_config_by_id の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: config is not None / config.line_group_id が "G1" である
-    # reply_service: なし
-    # DB操作: created = group_setting_repository.create(GroupSetting(line_group_id="G1"))
+def test_execute_returns_config_by_line_group_id():
+    # 目的: line_group_id でグループの設定を取得できること
+    # 入力: G1 グループを作成
+    # 想定出力: config is not None / EmbeddedGroupSettings インスタンスである
     # Arrange
-    created = group_setting_repository.create(GroupSetting(line_group_id="G1"))
+    group_repository.create(Group(line_group_id="G1", mode=GroupMode.wait.value))
     use_case = GetConfigForWebUseCase()
 
     # Act
-    config = use_case.execute(created._id)
+    config = use_case.execute("G1")
 
     # Assert
     assert config is not None
-    assert config.line_group_id == "G1"
+    assert isinstance(config, EmbeddedGroupSettings)
 
 
-def test_execute_returns_none_for_missing_id():
-    # 目的: test_execute_returns_none_for_missing_id の挙動を検証する。
+def test_execute_returns_none_for_missing_line_group_id():
+    # 目的: 存在しない line_group_id を指定した場合に None が返ること
     # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
     # 想定出力: config is None
-    # reply_service: なし
-    # DB操作: なし
     # Arrange
     use_case = GetConfigForWebUseCase()
 
     # Act
-    config = use_case.execute("000000000000000000000000")
+    config = use_case.execute("nonexistent_group_id")
 
     # Assert
     assert config is None

--- a/tests/use_cases/web/test__get_configs_for_web_use_case.py
+++ b/tests/use_cases/web/test__get_configs_for_web_use_case.py
@@ -1,18 +1,15 @@
-from domain_model.entities.group_setting import GroupSetting
-from repositories import group_setting_repository
+from domain_model.entities.group import Group, GroupMode
+from repositories import group_repository
 from use_cases.web.get_configs_for_web_use_case import GetConfigsForWebUseCase
 
 
 def test_execute_returns_configs():
-    # 目的: test_execute_returns_configs の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
+    # 目的: グループが 2 件存在する場合に configs が 2 件返ること
+    # 入力: group_repository に G1, G2 を作成
     # 想定出力: configs の件数が 2 件
-    # reply_service: なし
-    # DB操作: group_setting_repository.create(GroupSetting(line_group_id="G1")); group_setting_repository.create(GroupSetting(line_group_id="G2"))
     # Arrange
-    group_setting_repository.create(GroupSetting(line_group_id="G1"))
-    group_setting_repository.create(GroupSetting(line_group_id="G2"))
+    group_repository.create(Group(line_group_id="G1", mode=GroupMode.wait.value))
+    group_repository.create(Group(line_group_id="G2", mode=GroupMode.wait.value))
     use_case = GetConfigsForWebUseCase()
 
     # Act
@@ -23,12 +20,9 @@ def test_execute_returns_configs():
 
 
 def test_execute_returns_empty_list():
-    # 目的: test_execute_returns_empty_list の挙動を検証する。
+    # 目的: グループが 0 件の場合に空リストが返ること
     # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
     # 想定出力: configs が [] である
-    # reply_service: なし
-    # DB操作: なし
     # Arrange
     use_case = GetConfigsForWebUseCase()
 

--- a/tests/use_cases/web/test__get_configs_for_web_use_case.py
+++ b/tests/use_cases/web/test__get_configs_for_web_use_case.py
@@ -17,6 +17,8 @@ def test_execute_returns_configs():
 
     # Assert
     assert len(configs) == 2
+    assert all(isinstance(c, dict) for c in configs)
+    assert all("_id" in c for c in configs)
 
 
 def test_execute_returns_empty_list():

--- a/tests/use_cases/web/test__update_config_for_web_use_case.py
+++ b/tests/use_cases/web/test__update_config_for_web_use_case.py
@@ -1,24 +1,20 @@
 from _web_test_utils import create_app, request_context
 
-from domain_model.entities.group_setting import GroupSetting
-from repositories import group_setting_repository
+from domain_model.entities.group import Group, GroupMode
+from repositories import group_repository
 from use_cases.web.update_config_for_web_use_case import UpdateConfigForWebUseCase
 
 
 def test_execute_updates_group_setting_fields():
-    # 目的: test_execute_updates_group_setting_fields の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: updated.rate が 3 である / updated.rounding_method が 2 である
-    # reply_service: なし
-    # DB操作: created = group_setting_repository.create(GroupSetting(line_group_id="G1", rate=1)); updated = group_setting_repository.find({"_id": created._id})[0]
+    # 目的: フォームの値でグループの embedded settings が更新されること
+    # 入力: G1 グループを作成し rate=3, rounding_method=2 を送信
+    # 想定出力: g1.settings.rate が 3 / g1.settings.rounding_method が 2
     # Arrange
-    created = group_setting_repository.create(GroupSetting(line_group_id="G1", rate=1))
+    group_repository.create(Group(line_group_id="G1", mode=GroupMode.wait.value))
     app = create_app()
     use_case = UpdateConfigForWebUseCase()
 
     form = {
-        "_id": str(created._id),
         "line_group_id": "G1",
         "rate": "3",
         "rounding_method": "2",
@@ -29,31 +25,27 @@ def test_execute_updates_group_setting_fields():
         use_case.execute()
 
     # Assert
-    updated = group_setting_repository.find({"_id": created._id})[0]
-    assert updated.rate == 3
-    assert updated.rounding_method == 2
+    g1 = group_repository.find({"line_group_id": "G1"})[0]
+    assert g1.settings is not None
+    assert g1.settings.rate == 3
+    assert g1.settings.rounding_method == 2
 
 
-def test_execute_with_no_fields_does_nothing():
-    # 目的: test_execute_with_no_fields_does_nothing の挙動を検証する。
-    # 入力: なし
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: updated.rate が 1 である
-    # reply_service: なし
-    # DB操作: created = group_setting_repository.create(GroupSetting(line_group_id="G1", rate=1)); updated = group_setting_repository.find({"_id": created._id})[0]
+def test_execute_with_no_line_group_id_does_nothing():
+    # 目的: フォームに line_group_id がない場合は早期 return されること
+    # 入力: G1 グループを作成し line_group_id なしのフォームを送信
+    # 想定出力: G1 の settings は変わらない (None のまま)
     # Arrange
-    created = group_setting_repository.create(GroupSetting(line_group_id="G1", rate=1))
+    group_repository.create(Group(line_group_id="G1", mode=GroupMode.wait.value))
     app = create_app()
     use_case = UpdateConfigForWebUseCase()
 
-    form = {
-        "_id": str(created._id),
-    }
+    form = {}  # line_group_id なし → 早期 return
 
     # Act
     with request_context(app, form_data=form):
         use_case.execute()
 
     # Assert
-    updated = group_setting_repository.find({"_id": created._id})[0]
-    assert updated.rate == 1
+    g1 = group_repository.find({"line_group_id": "G1"})[0]
+    assert g1.settings is None


### PR DESCRIPTION
Batch 1 — 独立した品質改善:
- DEP-01: requirements.txt を本番用に絞り requirements-dev.txt を新設
- SEC-03: /auth/login を本番環境で 404 返却（暫定セキュリティ対応）
- UC-01: finish_match_use_case で add_image(None) を防ぐ None チェック追加
- LINE-03: reply_service.reply() 失敗時の push fallback 追加
- UC-07: ranking_table_image_builder に GCS 対応（新規ファイル追加）
- REPO-03/04/06: limit 上限・update_many 見直し・MongoDB インデックス定義
- DOM-04: find_or_create の TOCTOU を upsert で解消
- LINE-06/07/11/12/13/14 / UC-10/13 / DOM-11: 軽微な品質修正

Batch 2 — DB構造変更:
- DB-02: group_settings を Group に embedded 化（EmbeddedGroupSettings）
  - group_setting_repository / group_setting_service を group_service に統合
  - migrate_group_settings.py 追加
- DB-04: match.sum_scores を Dict→List 形式に変換（repository 層で透過的処理）
  - migrate_sum_scores.py 追加
- DB-03: user_hanchans を hanchan.results として embedded 化
  - UserHanchanResult dataclass 新設、Hanchan.results フィールド追加
  - user_hanchan_service を hanchan_repository ベースに書き換え
  - submit_hanchan_use_case: user_hanchan_repository.create() → hanchan_service.set_results()
  - migrate_user_hanchans.py 追加

テスト: 638 passed, 7 skipped