### PR TITLE
feat: 成績推移グラフ改善 + ランキング表リファクタリング + ログ整備

### DIFF
--- a/src/apis/api/_auth.py
+++ b/src/apis/api/_auth.py
@@ -1,5 +1,6 @@
 """API認証ヘルパー: JWT から WebUser を取得するデコレータ"""
 import functools
+import logging
 from typing import Callable
 
 from bson.objectid import ObjectId
@@ -7,6 +8,8 @@ from flask import jsonify, make_response
 from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
 
 from repositories import user_group_repository, web_user_repository
+
+logger = logging.getLogger(__name__)
 
 
 def require_web_user(f: Callable) -> Callable:
@@ -19,12 +22,14 @@ def require_web_user(f: Callable) -> Callable:
         try:
             verify_jwt_in_request()
         except Exception:
+            logger.warning("JWT verification failed")
             return make_response(jsonify({"error": "Unauthorized"}), 401)
 
         identity = get_jwt_identity()
         try:
             web_users = web_user_repository.find({"_id": ObjectId(identity)})
         except Exception:
+            logger.warning("WebUser lookup failed for identity: %s", identity)
             return make_response(jsonify({"error": "Unauthorized"}), 401)
 
         if len(web_users) == 0:

--- a/src/apis/root.py
+++ b/src/apis/root.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from flask import (
@@ -11,6 +12,8 @@ from flask import (
     session,
 )
 from linebot.v3.exceptions import InvalidSignatureError
+
+logger = logging.getLogger(__name__)
 
 from application_models.page_contents import PageContents
 
@@ -42,6 +45,7 @@ def callback():
     try:
         handler.handle(body, signature)
     except InvalidSignatureError:
+        logger.warning("Invalid LINE signature")
         abort(400)
     return "OK"
 

--- a/src/domain_service/user_service.py
+++ b/src/domain_service/user_service.py
@@ -49,6 +49,7 @@ class UserService(IUserService):
             return _cached_get_profile_name(line_user_id, hour_bucket)
 
         except Exception:
+            logger.warning("LINE API profile fetch failed, falling back to DB: user_id=%s", line_user_id)
             target = user_repository.find(
                 query={"line_user_id": line_user_id},
             )

--- a/src/handle_event.py
+++ b/src/handle_event.py
@@ -1,7 +1,6 @@
 """LINE messaging API handler"""
 
 import logging
-import traceback
 from functools import wraps
 
 from linebot.v3.webhook import WebhookHandler
@@ -45,7 +44,7 @@ def handle_event_decorator(function):
             function(args[0])
 
         except Exception as err:
-            traceback.print_exc()
+            logger.exception("Unhandled exception in event handler")
             reply_service.push_a_message(
                 to=env_var.SERVER_ADMIN_LINE_USER_ID,
                 message=f"システムエラー: {type(err).__name__}: {err}",

--- a/src/use_cases/group_line/execute_history_use_case.py
+++ b/src/use_cases/group_line/execute_history_use_case.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Tuple
 
@@ -15,6 +16,7 @@ from domain_service import (
 )
 from repositories import history_session_repository
 
+logger = logging.getLogger(__name__)
 _TIMEOUT_MSG = "タイムアウトしました。その他メニューの「成績推移」から再度お試しください。"
 
 
@@ -48,6 +50,7 @@ class ExecuteHistoryUseCase:
 
         session = history_session_repository.find_active_by_group_id(group_id)
         if session is None:
+            logger.warning("history session timeout or not found: group=%s", group_id)
             reply_service.add_message(_TIMEOUT_MSG)
             return
 

--- a/src/use_cases/group_line/finish_match_use_case.py
+++ b/src/use_cases/group_line/finish_match_use_case.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict
 
 from application_service import (
@@ -15,6 +16,8 @@ from domain_service import (
 from use_cases.group_line.create_match_detail_graph_use_case import (
     CreateMatchDetailGraphUseCase,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class FinishMatchUseCase:
@@ -86,6 +89,7 @@ class FinishMatchUseCase:
         group.mode = GroupMode.wait.value
         group.active_match_id = None
         group_service.update(group)
+        logger.info("finish match: group=%s match=%s hanchans=%d", line_group_id, active_match._id, len(hanchans))
 
         # 応答メッセージ作成
         reply_service.add_message(

--- a/src/use_cases/group_line/group_quit_use_case.py
+++ b/src/use_cases/group_line/group_quit_use_case.py
@@ -1,3 +1,5 @@
+import logging
+
 from application_service import (
     request_info_service,
 )
@@ -5,8 +7,12 @@ from domain_service import (
     group_service,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class GroupQuitUseCase:
 
     def execute(self) -> None:
-        group_service.delete_by_line_group_id(request_info_service.req_line_group_id)
+        line_group_id = request_info_service.req_line_group_id
+        logger.info("group quit: group=%s", line_group_id)
+        group_service.delete_by_line_group_id(line_group_id)

--- a/src/use_cases/group_line/join_group_use_case.py
+++ b/src/use_cases/group_line/join_group_use_case.py
@@ -1,3 +1,5 @@
+import logging
+
 from application_service import (
     reply_service,
     request_info_service,
@@ -6,12 +8,15 @@ from domain_service import (
     group_service,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class JoinGroupUseCase:
     def execute(self) -> None:
         line_group_id = request_info_service.req_line_group_id
         if line_group_id is None:
             raise ValueError("登録する line_group_id が未指定です。")
+        logger.info("join group: group=%s", line_group_id)
         group_service.find_or_create(line_group_id)
         reply_service.add_message(
             "麻雀の成績管理Botです。参加者は友達登録してください。",

--- a/src/use_cases/group_line/reply_ranking_table_use_case.py
+++ b/src/use_cases/group_line/reply_ranking_table_use_case.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
@@ -19,6 +20,8 @@ from domain_service import (
     user_service,
 )
 from messaging_api_setting import line_bot_api
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -204,6 +207,7 @@ class ReplyRankingTableUseCase:
         )
 
     def _handle_image_save_error(self) -> None:
+        logger.error("ranking table image save failed: group=%s", request_info_service.req_line_group_id)
         reply_service.reset()
         reply_service.add_message(text="システムエラーが発生しました。")
         messages = [

--- a/src/use_cases/personal_line/follow_use_case.py
+++ b/src/use_cases/personal_line/follow_use_case.py
@@ -1,3 +1,5 @@
+import logging
+
 from application_service import (
     reply_service,
     request_info_service,
@@ -8,6 +10,8 @@ from domain_service import (
 )
 from messaging_api_setting import line_bot_api
 
+logger = logging.getLogger(__name__)
+
 
 class FollowUseCase:
 
@@ -17,6 +21,7 @@ class FollowUseCase:
             request_info_service.req_line_user_id,
         )
         user = user_service.find_or_create_by_profile(profile)
+        logger.info("follow: user=%s (%s)", user.line_user_id, user.line_user_name)
         reply_service.add_message(
             f"こんにちは。\n麻雀対戦結果管理アカウントである Mahjong Manager は {user.line_user_name} さんの快適な麻雀生活をサポートします。")
         rich_menu_service.create_and_link(

--- a/src/use_cases/personal_line/unfollow_use_case.py
+++ b/src/use_cases/personal_line/unfollow_use_case.py
@@ -1,3 +1,5 @@
+import logging
+
 from application_service import (
     request_info_service,
 )
@@ -5,13 +7,17 @@ from repositories import (
     user_repository,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class UnfollowUseCase:
 
     def execute(self) -> None:
         """Unfollow event"""
+        line_user_id = request_info_service.req_line_user_id
+        logger.info("unfollow: user=%s", line_user_id)
         user_repository.delete(
             query={
-                "line_user_id": request_info_service.req_line_user_id,
+                "line_user_id": line_user_id,
             },
         )


### PR DESCRIPTION
## Summary
- 成績推移グラフの改善: ステップグラフ対応、グループチャットでのインタラクティブUI（ユーザー選択→期間選択→グラフ生成）
- ランキング表画像生成のリファクタリング: `RankingTableImageBuilder` クラスに PIL 画像生成ロジックを分離、GCS/ローカル保存の統一パターン適用
- ログ整備: 未ログの except ブロックとライフサイクルイベントに logging 追加
- lint 修正: ruff ANN401、重複定義、その他の lint エラー対応

## Changes
- `src/application_service/ranking_table_image_builder.py` — 新規: PIL画像生成を専用クラスに分離
- `src/application_service/graph_service.py` — ステップグラフ生成(`build_history_step_graph`)追加
- `src/use_cases/group_line/execute_history_use_case.py` — 新規: 成績推移フロー統合ユースケース
- `src/use_cases/group_line/reply_ranking_table_use_case.py` — リファクタ: builder委譲 + メソッド分割
- 各ユースケースに logging 追加

## Test plan
- [ ] `pytest tests/` 全テスト PASS 確認
- [ ] ランキング表コマンドの動作確認（LINE Bot 経由）
- [ ] 成績推移コマンドの動作確認（グループチャット）

🤖 Generated with [Claude Code](https://claude.com/claude-code)