### PR TITLE
feat: add customizable unit label (default: pt)

### DIFF
--- a/src/application_service/message_service.py
+++ b/src/application_service/message_service.py
@@ -126,7 +126,7 @@ class MessageService(IMessageService):
     def get_finish_hanchan_message(self) -> str:
         return random.choice(finish_hanchan_messages)
 
-    def create_show_match_result(self, match: Match) -> str:
+    def create_show_match_result(self, match: Match, unit: str = "pt") -> str:
         sum_prices_with_chip = match.sum_prices_with_chip
         chip_scores = match.chip_scores
         sum_scores = match.sum_scores
@@ -142,7 +142,7 @@ class MessageService(IMessageService):
             )
 
             show_prize_money_list.append(
-                f"{name}: {price!s}円 ({show_score}{additional_chip_message})",
+                f"{name}: {price!s}{unit} ({show_score}{additional_chip_message})",
             )
         return "\n".join(show_prize_money_list)
 

--- a/src/domain_model/entities/group_setting.py
+++ b/src/domain_model/entities/group_setting.py
@@ -35,6 +35,7 @@ class EmbeddedGroupSettings:
     tobi_prize: int = 10
     num_of_players: int = 4
     rounding_method: int = RoundingMethod.go_san_roku
+    unit: str = "pt"
 
     def __post_init__(self):  # noqa: D105
         if self.ranking_prize is None:
@@ -48,6 +49,7 @@ class EmbeddedGroupSettings:
             "tobi_prize": self.tobi_prize,
             "num_of_players": self.num_of_players,
             "rounding_method": self.rounding_method,
+            "unit": self.unit,
         }
 
     @classmethod
@@ -59,6 +61,7 @@ class EmbeddedGroupSettings:
             tobi_prize=d.get("tobi_prize", 10),
             num_of_players=d.get("num_of_players", 4),
             rounding_method=d.get("rounding_method", RoundingMethod.go_san_roku),
+            unit=d.get("unit", "pt"),
         )
 
 

--- a/src/domain_model/entities/group_setting.py
+++ b/src/domain_model/entities/group_setting.py
@@ -73,6 +73,7 @@ class GroupSetting:
     tobi_prize: int = 10
     num_of_players: int = 4
     rounding_method: int = RoundingMethod.go_san_roku
+    unit: str = "pt"
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
     _id: ObjectId = field(default=None)

--- a/src/repositories/group_setting_repository.py
+++ b/src/repositories/group_setting_repository.py
@@ -80,6 +80,7 @@ class GroupSettingRepository(IGroupSettingRepository):
             chip_rate=record.get("chip_rate"),
             num_of_players=record.get("num_of_players"),
             rounding_method=record.get("rounding_method"),
+            unit=record.get("unit", "pt"),
             created_at=record.get("created_at"),
             updated_at=record.get("updated_at"),
         )

--- a/src/routing_by_text_in_group_line.py
+++ b/src/routing_by_text_in_group_line.py
@@ -46,9 +46,9 @@ from use_cases.group_line.select_history_target_use_case import (
     SelectHistoryTargetUseCase,
 )
 from use_cases.group_line.simulate_score_use_case import SimulateScoreUseCase
-from use_cases.group_line.start_sim_use_case import StartSimUseCase
 from use_cases.group_line.start_history_flow_use_case import StartHistoryFlowUseCase
 from use_cases.group_line.start_input_use_case import StartInputUseCase
+from use_cases.group_line.start_sim_use_case import StartSimUseCase
 from use_cases.group_line.submit_hanchan_use_case import SubmitHanchanUseCase
 from use_cases.group_line.toggle_history_user_use_case import ToggleHistoryUserUseCase
 from use_cases.group_line.update_group_settings_use_case import (
@@ -169,8 +169,9 @@ def routing_for_group_by_command(command):
     body = request_info_service.body
 
     def _update_config():
-        key = body.split(" ")[0]
-        value = body.split(" ")[1]
+        parts = body.split(" ", 1)
+        key = parts[0]
+        value = parts[1] if len(parts) > 1 else ""
         UpdateGroupSettingsUseCase().execute(key, value)
 
     def _tobi():

--- a/src/use_cases/group_line/finish_match_use_case.py
+++ b/src/use_cases/group_line/finish_match_use_case.py
@@ -94,7 +94,7 @@ class FinishMatchUseCase:
         # 応答メッセージ作成
         reply_service.add_message(
             "【対戦結果】 \n"
-            + message_service.create_show_match_result(match=active_match),
+            + message_service.create_show_match_result(match=active_match, unit=settings.unit),
         )
 
         image_url = CreateMatchDetailGraphUseCase().execute(active_match._id)

--- a/src/use_cases/group_line/reply_apply_badai_use_case.py
+++ b/src/use_cases/group_line/reply_apply_badai_use_case.py
@@ -3,6 +3,7 @@ from application_service import (
     request_info_service,
 )
 from domain_service import (
+    group_setting_service,
     match_service,
     user_service,
 )
@@ -37,24 +38,27 @@ class ReplyApplyBadaiUseCase:
 
         player_count = len(latest_match.sum_prices_with_chip)
 
+        setting = group_setting_service.find_or_create(line_group_id)
+        unit = setting.unit
+
         badai_per_player = badai // player_count
         fraction = badai % player_count
         if fraction != 0:
             badai_per_player += 1
             fraction -= player_count
-        str_fraction = "" if fraction == 0 else str(fraction) + "円"
+        str_fraction = "" if fraction == 0 else str(fraction) + unit
 
         str_each_price = []
         for u_id, p in latest_match.sum_prices_with_chip.items():
             name = user_service.get_name_by_line_user_id(u_id) or "友達未登録"
-            str_each_price.append(f"{name}: {p - badai_per_player}円")
+            str_each_price.append(f"{name}: {p - badai_per_player}{unit}")
 
         reply_service.add_message("直前の対戦の最終会計を表示します。")
         reply_service.add_message(
             "対戦開始日: "
             + latest_match.created_at.strftime("%Y年%m月%d日")
             + "\n"
-            + f"場代: {badai}円({badai_per_player}円×{player_count}人{str_fraction})"
+            + f"場代: {badai}{unit}({badai_per_player}{unit}×{player_count}人{str_fraction})"
             + "\n"
             + "\n".join(str_each_price),
         )

--- a/src/use_cases/group_line/reply_group_settings_menu_use_case.py
+++ b/src/use_cases/group_line/reply_group_settings_menu_use_case.py
@@ -24,5 +24,6 @@ class ReplyGroupSettingsMenuUseCase:
             s.append(f"飛び賞: {settings.tobi_prize}点")
             s.append(f"チップ: 1枚{settings.chip_rate}点")
             s.append(f"計算方法: {ROUNDING_METHOD_LIST[settings.rounding_method]}")
+            s.append(f"単位: {settings.unit}")
             reply_service.add_message("\n".join(s))
         reply_service.add_settings_menu(body)

--- a/src/use_cases/group_line/reply_match_by_index_use_case.py
+++ b/src/use_cases/group_line/reply_match_by_index_use_case.py
@@ -4,6 +4,7 @@ from application_service import (
     request_info_service,
 )
 from domain_service import (
+    group_setting_service,
     hanchan_service,
     match_service,
 )
@@ -30,7 +31,8 @@ class ReplyMatchByIndexUseCase:
             return
 
         match = archived_matches[index-1]
-        result = message_service.create_show_match_result(match=match)
+        setting = group_setting_service.find_or_create(line_group_id)
+        result = message_service.create_show_match_result(match=match, unit=setting.unit)
 
         reply_service.add_message(f'第{index}回\n{match.created_at.strftime("%Y年%m月%d日")}\n{result}')
 

--- a/src/use_cases/group_line/update_group_settings_use_case.py
+++ b/src/use_cases/group_line/update_group_settings_use_case.py
@@ -60,6 +60,13 @@ class UpdateGroupSettingsUseCase:
                     reply_service.add_message(f"[{key}]を[{value}]に変更できません")
                     return
                 display_value = ROUNDING_METHOD_LIST[db_value]
+            elif key == "単位":
+                column = "unit"
+                db_value = value.strip()
+                if not db_value or len(db_value) > 10:
+                    reply_service.add_message(f"[{key}]を[{value}]に変更できません（10文字以内）")
+                    return
+                display_value = db_value
             else:
                 reply_service.add_message(
                     f"項目[{key}]は未知の項目のため、[{key}]を[{value}]に変更できません",

--- a/tests/application_service/message_service/test_message_service_create_show_match_result.py
+++ b/tests/application_service/message_service/test_message_service_create_show_match_result.py
@@ -43,7 +43,7 @@ def test_success_with_unknown_users(mocker):
     # Assert
     assert (
         result
-        == "友達未登録: 3100円 (+100(+10枚))\n友達未登録: 600円 (+20(0枚))\n友達未登録: -1300円 (-40(-10枚))\n友達未登録: -1200円 (-40(0枚))\n友達未登録: -1200円 (-40(0枚))"
+        == "友達未登録: 3100pt (+100(+10枚))\n友達未登録: 600pt (+20(0枚))\n友達未登録: -1300pt (-40(-10枚))\n友達未登録: -1200pt (-40(0枚))\n友達未登録: -1200pt (-40(0枚))"
     )
 
 
@@ -74,5 +74,5 @@ def test_success(mocker):
     # Assert
     assert (
         result
-        == "test_user1: 3100円 (+100(+10枚))\ntest_user2: 600円 (+20(0枚))\ntest_user3: -1300円 (-40(-10枚))\ntest_user4: -1200円 (-40(0枚))\ntest_user5: -1200円 (-40(0枚))"
+        == "test_user1: 3100pt (+100(+10枚))\ntest_user2: 600pt (+20(0枚))\ntest_user3: -1300pt (-40(-10枚))\ntest_user4: -1200pt (-40(0枚))\ntest_user5: -1200pt (-40(0枚))"
     )

--- a/tests/use_cases/group_line/test__finish_input_chip_use_case.py
+++ b/tests/use_cases/group_line/test__finish_input_chip_use_case.py
@@ -290,8 +290,8 @@ def test_success():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 150円 (+100(+3枚))\ntest_user2: -150円 (+20(-3枚))\n"
-        + "test_user3: 0円 (-40(0枚))\ntest_user4: 0円 (-40(0枚))\ntest_user5: 0円 (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 150pt (+100(+3枚))\ntest_user2: -150pt (+20(-3枚))\n"
+        + "test_user3: 0pt (-40(0枚))\ntest_user4: 0pt (-40(0枚))\ntest_user5: 0pt (-40(0枚))"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value

--- a/tests/use_cases/group_line/test__finish_match_use_case.py
+++ b/tests/use_cases/group_line/test__finish_match_use_case.py
@@ -176,7 +176,7 @@ def test_success_with_default_settings():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 0円 (+100(0枚))\ntest_user2: 0円 (+20(0枚))\ntest_user3: 0円 (-40(0枚))\ntest_user4: 0円 (-40(0枚))\ntest_user5: 0円 (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 0pt (+100(0枚))\ntest_user2: 0pt (+20(0枚))\ntest_user3: 0pt (-40(0枚))\ntest_user4: 0pt (-40(0枚))\ntest_user5: 0pt (-40(0枚))"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value
@@ -220,8 +220,8 @@ def test_success():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 5000円 (+100(0枚))\ntest_user2: 1000円 (+20(0枚))\n"
-        + "test_user3: -2000円 (-40(0枚))\ntest_user4: -2000円 (-40(0枚))\ntest_user5: -2000円 (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 5000pt (+100(0枚))\ntest_user2: 1000pt (+20(0枚))\n"
+        + "test_user3: -2000pt (-40(0枚))\ntest_user4: -2000pt (-40(0枚))\ntest_user5: -2000pt (-40(0枚))"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value
@@ -342,8 +342,8 @@ def test_success_with_chip():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 150円 (+100(+3枚))\ntest_user2: -150円 (+20(-3枚))\n"
-        + "test_user3: 0円 (-40(0枚))\ntest_user4: 0円 (-40(0枚))\ntest_user5: 0円 (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 150pt (+100(+3枚))\ntest_user2: -150pt (+20(-3枚))\n"
+        + "test_user3: 0pt (-40(0枚))\ntest_user4: 0pt (-40(0枚))\ntest_user5: 0pt (-40(0枚))"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value

--- a/tests/use_cases/group_line/test__reply_apply_badai_use_case.py
+++ b/tests/use_cases/group_line/test__reply_apply_badai_use_case.py
@@ -130,7 +130,7 @@ def test_execute():
     assert reply_service.texts[0].text == "直前の対戦の最終会計を表示します。"
     assert (
         reply_service.texts[1].text
-        == "対戦開始日: 2010年01月01日\n場代: 3000円(500円×6人)\ntest_user1: 500円\ntest_user2: 1300円\ntest_user3: -2300円\ntest_user4: -900円\ntest_user5: -800円\n友達未登録: -800円"
+        == "対戦開始日: 2010年01月01日\n場代: 3000pt(500pt×6人)\ntest_user1: 500pt\ntest_user2: 1300pt\ntest_user3: -2300pt\ntest_user4: -900pt\ntest_user5: -800pt\n友達未登録: -800pt"
     )
 
 
@@ -157,7 +157,7 @@ def test_execute_with_fraction():
     assert reply_service.texts[0].text == "直前の対戦の最終会計を表示します。"
     assert (
         reply_service.texts[1].text
-        == "対戦開始日: 2010年01月01日\n場代: 2996円(500円×6人-4円)\ntest_user1: 500円\ntest_user2: 1300円\ntest_user3: -2300円\ntest_user4: -900円\ntest_user5: -800円\n友達未登録: -800円"
+        == "対戦開始日: 2010年01月01日\n場代: 2996pt(500pt×6人-4pt)\ntest_user1: 500pt\ntest_user2: 1300pt\ntest_user3: -2300pt\ntest_user4: -900pt\ntest_user5: -800pt\n友達未登録: -800pt"
     )
 
 

--- a/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
+++ b/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
@@ -50,7 +50,7 @@ def test_execute():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "[設定]\n4人麻雀\nレート: 点3\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: 1枚1点\n計算方法: 3万点以下切り上げ/以上切り捨て"
+        == "[設定]\n4人麻雀\nレート: 点3\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: 1枚1点\n計算方法: 3万点以下切り上げ/以上切り捨て\n単位: pt"
     )
     assert len(reply_service.buttons) == 1
     assert isinstance(reply_service.buttons[0], TemplateMessage)
@@ -74,7 +74,7 @@ def test_execute_no_settings():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "[設定]\n4人麻雀\nレート: 点0\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: 1枚0点\n計算方法: 五捨六入"
+        == "[設定]\n4人麻雀\nレート: 点0\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: 1枚0点\n計算方法: 五捨六入\n単位: pt"
     )
     assert len(reply_service.buttons) == 1
     assert isinstance(reply_service.buttons[0], TemplateMessage)

--- a/tests/use_cases/group_line/test__reply_match_by_index_use_case.py
+++ b/tests/use_cases/group_line/test__reply_match_by_index_use_case.py
@@ -165,7 +165,7 @@ def test_execute():
     assert len(reply_service.texts) == 2
     assert (
         reply_service.texts[0].text
-        == "第2回\n2010年01月01日\ntest_user1: 1000円 (+30(+10枚))\ntest_user2: 1800円 (+60(0枚))\ntest_user3: -1800円 (-60(0枚))\ntest_user4: -400円 (-10(-10枚))\ntest_user5: -300円 (-10(0枚))\n友達未登録: -300円 (-10(0枚))"
+        == "第2回\n2010年01月01日\ntest_user1: 1000pt (+30(+10枚))\ntest_user2: 1800pt (+60(0枚))\ntest_user3: -1800pt (-60(0枚))\ntest_user4: -400pt (-10(-10枚))\ntest_user5: -300pt (-10(0枚))\n友達未登録: -300pt (-10(0枚))"
     )
     assert (
         reply_service.texts[1].text


### PR DESCRIPTION
## Summary
- `GroupSetting` に `unit` フィールド追加（デフォルト: `pt`）
- `_update_config 単位 円` で変更可能（10文字以内の任意テキスト）
- `_setting` で現在の単位を表示
- 清算結果・場代計算・試合詳細の全メッセージで `unit` を使用

## Test plan
- [ ] `_setting` → 設定一覧に「単位: pt」が表示
- [ ] `_update_config 単位 円` → 「[単位]を[円]に変更しました。」
- [ ] 清算結果で「xxxpt」→「xxx円」に変更されている
- [ ] 既存テスト 565 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)