### PR TITLE
feat: revamp chip calculation (1 chip = 1 point)

### DIFF
--- a/src/application_service/message_service.py
+++ b/src/application_service/message_service.py
@@ -132,17 +132,21 @@ class MessageService(IMessageService):
         sum_scores = match.sum_scores
 
         show_prize_money_list = []
+        has_chip = any(v != 0 for v in chip_scores.values()) if chip_scores else False
         for line_user_id, score in sum_scores.items():
             name = user_service.get_name_by_line_user_id(line_user_id) or "友達未登録"
             show_score = ("+" if score > 0 else "") + str(score)
             price = sum_prices_with_chip.get(line_user_id, 0)
-            chip_count = chip_scores.get(line_user_id, 0)
-            additional_chip_message = (
-                f"({('+' if chip_count > 0 else '') + str(chip_count)}枚)"
-            )
+
+            if has_chip:
+                chip_count = chip_scores.get(line_user_id, 0)
+                chip_str = f" / チップ{('+' if chip_count > 0 else '')}{chip_count}枚"
+                detail = f" ({show_score}{chip_str})"
+            else:
+                detail = f" ({show_score})"
 
             show_prize_money_list.append(
-                f"{name}: {price!s}{unit} ({show_score}{additional_chip_message})",
+                f"{name}: {price!s}{unit}{detail}",
             )
         return "\n".join(show_prize_money_list)
 

--- a/src/application_service/reply_service.py
+++ b/src/application_service/reply_service.py
@@ -355,42 +355,14 @@ class ReplyService(IReplyService):
                         text="どれにしますか？",
                         actions=[
                             PostbackAction(
-                                label=f"1枚{i}円",
-                                display_text=f"1枚{i}円",
-                                data=f"_update_config チップ {i}",
-                            )
-                            for i in [0, 10, 30]
-                        ]
-                        + [
-                            PostbackAction(
-                                label="1枚50円以上",
-                                display_text="1枚50円以上",
-                                data="_setting 高チップ",
+                                label="なし",
+                                display_text="なし",
+                                data="_update_config チップ 0",
                             ),
-                        ],
-                    ),
-                ),
-            )
-        elif key == "高チップ":
-            self.buttons.append(
-                TemplateMessage(
-                    alt_text="高チップ設定",
-                    template=ButtonsTemplate(
-                        title="チップ",
-                        text="どれにしますか？",
-                        actions=[
                             PostbackAction(
-                                label=f"1枚{i}円",
-                                display_text=f"1枚{i}円",
-                                data=f"_update_config チップ {i}",
-                            )
-                            for i in [50, 100, 500]
-                        ]
-                        + [
-                            PostbackAction(
-                                label="1枚30円以下",
-                                display_text="1枚30円以下",
-                                data="_setting チップ",
+                                label="あり(1枚=1点)",
+                                display_text="あり(1枚=1点)",
+                                data="_update_config チップ 1",
                             ),
                         ],
                     ),

--- a/src/application_service/reply_service.py
+++ b/src/application_service/reply_service.py
@@ -395,6 +395,24 @@ class ReplyService(IReplyService):
             ),
         )
 
+    def add_chip_complete_button(self) -> None:
+        self.buttons.append(
+            TemplateMessage(
+                alt_text="チップ入力完了",
+                template=ButtonsTemplate(
+                    title="チップ入力",
+                    text="各自のチップ増減数を入力してください。\n全員分の入力が完了したらボタンを押してください。",
+                    actions=[
+                        PostbackAction(
+                            label="入力完了",
+                            display_text="入力完了",
+                            data="_chip_ok",
+                        ),
+                    ],
+                ),
+            ),
+        )
+
     def add_submit_results_by_ocr_menu(self, results: Dict[str, int]) -> None:
         self.buttons.append(
             TemplateMessage(

--- a/src/use_cases/group_line/finish_match_use_case.py
+++ b/src/use_cases/group_line/finish_match_use_case.py
@@ -53,9 +53,7 @@ class FinishMatchUseCase:
         ):
             group.mode = GroupMode.chip_input.value
             group_service.update(group)
-            reply_service.add_message(
-                "チップの増減数を入力してください。完了したら「_chip_ok」と入力してください。",
-            )
+            reply_service.add_chip_complete_button()
             return
 
         # 精算

--- a/src/use_cases/group_line/finish_match_use_case.py
+++ b/src/use_cases/group_line/finish_match_use_case.py
@@ -63,26 +63,18 @@ class FinishMatchUseCase:
         sum_scores = active_match.sum_scores
         chip_scores = active_match.chip_scores
 
-        chip_prices: Dict[str, int] = {}
         sum_prices: Dict[str, int] = {}
         sum_prices_with_chip: Dict[str, int] = {}
         for line_user_id, converted_score in sum_scores.items():
-            if chip_scores.get(line_user_id) is None:
-                chip_score = 0
-                chip_scores[line_user_id] = 0
-            else:
-                chip_score = chip_scores.get(line_user_id)
-
-            chip_price = chip_score * chip_rate
-            chip_prices[line_user_id] = chip_price
-
-            price = converted_score * rate
-            sum_prices[line_user_id] = price
-
-            sum_prices_with_chip[line_user_id] = price + chip_price
+            chip_score = chip_scores.get(line_user_id, 0)
+            # チップを累計ポイントに加算してからレートを掛ける
+            total_score = converted_score + chip_score
+            price = total_score * rate
+            sum_prices[line_user_id] = converted_score * rate
+            sum_prices_with_chip[line_user_id] = price
 
         # 試合のアーカイブ
-        active_match.chip_prices = chip_prices
+        active_match.chip_prices = {}
         active_match.sum_prices = sum_prices
         active_match.sum_prices_with_chip = sum_prices_with_chip
         match_service.update(active_match)

--- a/src/use_cases/group_line/finish_match_use_case.py
+++ b/src/use_cases/group_line/finish_match_use_case.py
@@ -64,7 +64,8 @@ class FinishMatchUseCase:
         sum_prices: Dict[str, int] = {}
         sum_prices_with_chip: Dict[str, int] = {}
         for line_user_id, converted_score in sum_scores.items():
-            chip_score = chip_scores.get(line_user_id, 0)
+            # チップ設定が有効な場合のみチップを加算
+            chip_score = chip_scores.get(line_user_id, 0) if chip_rate != 0 else 0
             # チップを累計ポイントに加算してからレートを掛ける
             total_score = converted_score + chip_score
             price = total_score * rate

--- a/src/use_cases/group_line/reply_group_settings_menu_use_case.py
+++ b/src/use_cases/group_line/reply_group_settings_menu_use_case.py
@@ -22,7 +22,8 @@ class ReplyGroupSettingsMenuUseCase:
             s.append(f"レート: 点{settings.rate}")
             s.append(f"順位点: 1着{r[0]}/2着{r[1]}/3着{r[2]}/4着{r[3]}")
             s.append(f"飛び賞: {settings.tobi_prize}点")
-            s.append(f"チップ: 1枚{settings.chip_rate}点")
+            chip_display = "なし" if settings.chip_rate == 0 else "あり(1枚=1点)"
+            s.append(f"チップ: {chip_display}")
             s.append(f"計算方法: {ROUNDING_METHOD_LIST[settings.rounding_method]}")
             s.append(f"単位: {settings.unit}")
             reply_service.add_message("\n".join(s))

--- a/src/use_cases/group_line/update_group_settings_use_case.py
+++ b/src/use_cases/group_line/update_group_settings_use_case.py
@@ -35,10 +35,10 @@ class UpdateGroupSettingsUseCase:
             elif key == "チップ":
                 column = "chip_rate"
                 db_value = _parse_int(value)
-                if db_value not in [0, 10, 30, 50, 100, 500]:
+                if db_value not in [0, 1]:
                     reply_service.add_message(f"[{key}]を[{value}]に変更できません")
                     return
-                display_value = f"1枚{value}円"
+                display_value = "なし" if db_value == 0 else "あり(1枚=1点)"
             elif key == "飛び賞":
                 column = "tobi_prize"
                 db_value = _parse_int(value)

--- a/tests/application_service/message_service/test_message_service_create_show_match_result.py
+++ b/tests/application_service/message_service/test_message_service_create_show_match_result.py
@@ -43,7 +43,7 @@ def test_success_with_unknown_users(mocker):
     # Assert
     assert (
         result
-        == "友達未登録: 3100pt (+100(+10枚))\n友達未登録: 600pt (+20(0枚))\n友達未登録: -1300pt (-40(-10枚))\n友達未登録: -1200pt (-40(0枚))\n友達未登録: -1200pt (-40(0枚))"
+        == "友達未登録: 3100pt (+100 / チップ+10枚)\n友達未登録: 600pt (+20 / チップ0枚)\n友達未登録: -1300pt (-40 / チップ-10枚)\n友達未登録: -1200pt (-40 / チップ0枚)\n友達未登録: -1200pt (-40 / チップ0枚)"
     )
 
 
@@ -74,5 +74,5 @@ def test_success(mocker):
     # Assert
     assert (
         result
-        == "test_user1: 3100pt (+100(+10枚))\ntest_user2: 600pt (+20(0枚))\ntest_user3: -1300pt (-40(-10枚))\ntest_user4: -1200pt (-40(0枚))\ntest_user5: -1200pt (-40(0枚))"
+        == "test_user1: 3100pt (+100 / チップ+10枚)\ntest_user2: 600pt (+20 / チップ0枚)\ntest_user3: -1300pt (-40 / チップ-10枚)\ntest_user4: -1200pt (-40 / チップ0枚)\ntest_user5: -1200pt (-40 / チップ0枚)"
     )

--- a/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
+++ b/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
@@ -56,17 +56,6 @@ def test_success_key_chip():
     assert len(reply_service.buttons) == 1
 
 
-def test_success_key_high_high_chip():
-    # Arrange
-    reply_service = ReplyService()
-
-    # Act
-    reply_service.add_settings_menu("高チップ")
-
-    # Assert
-    assert len(reply_service.buttons) == 1
-
-
 def test_success_key_ranking_point():
     # Arrange
     reply_service = ReplyService()

--- a/tests/use_cases/group_line/test__finish_input_chip_use_case.py
+++ b/tests/use_cases/group_line/test__finish_input_chip_use_case.py
@@ -61,7 +61,7 @@ dummy_group = Group(
     _id=1,
 )
 
-dummy_embedded_settings = EmbeddedGroupSettings(chip_rate=50)
+dummy_embedded_settings = EmbeddedGroupSettings(chip_rate=1)
 
 dummy_match = Match(
     line_group_id=dummy_group.line_group_id,
@@ -290,8 +290,8 @@ def test_success():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 150pt (+100(+3枚))\ntest_user2: -150pt (+20(-3枚))\n"
-        + "test_user3: 0pt (-40(0枚))\ntest_user4: 0pt (-40(0枚))\ntest_user5: 0pt (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 0pt (+100 / チップ+3枚)\ntest_user2: 0pt (+20 / チップ-3枚)\n"
+        + "test_user3: 0pt (-40 / チップ0枚)\ntest_user4: 0pt (-40 / チップ0枚)\ntest_user5: 0pt (-40 / チップ0枚)"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value

--- a/tests/use_cases/group_line/test__finish_match_use_case.py
+++ b/tests/use_cases/group_line/test__finish_match_use_case.py
@@ -276,11 +276,8 @@ def test_success_with_chip_init():
     use_case.execute()
 
     # Assert
-    assert len(reply_service.texts) == 1
-    assert (
-        reply_service.texts[0].text
-        == "チップの増減数を入力してください。完了したら「_chip_ok」と入力してください。"
-    )
+    assert len(reply_service.texts) == 0
+    assert len(reply_service.buttons) == 1
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.chip_input.value
     assert groups[0].active_match_id == 1

--- a/tests/use_cases/group_line/test__finish_match_use_case.py
+++ b/tests/use_cases/group_line/test__finish_match_use_case.py
@@ -176,7 +176,7 @@ def test_success_with_default_settings():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 0pt (+100(0枚))\ntest_user2: 0pt (+20(0枚))\ntest_user3: 0pt (-40(0枚))\ntest_user4: 0pt (-40(0枚))\ntest_user5: 0pt (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 0pt (+100)\ntest_user2: 0pt (+20)\ntest_user3: 0pt (-40)\ntest_user4: 0pt (-40)\ntest_user5: 0pt (-40)"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value
@@ -220,8 +220,8 @@ def test_success():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 5000pt (+100(0枚))\ntest_user2: 1000pt (+20(0枚))\n"
-        + "test_user3: -2000pt (-40(0枚))\ntest_user4: -2000pt (-40(0枚))\ntest_user5: -2000pt (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 5000pt (+100)\ntest_user2: 1000pt (+20)\n"
+        + "test_user3: -2000pt (-40)\ntest_user4: -2000pt (-40)\ntest_user5: -2000pt (-40)"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value
@@ -229,12 +229,7 @@ def test_success():
 
     matches = match_repository.find({"_id": 1})
     assert not matches[0].is_deleted
-    assert len(matches[0].chip_prices) == 5
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu1"] == 0
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu2"] == 0
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu3"] == 0
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu4"] == 0
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu5"] == 0
+    assert matches[0].chip_prices == {}
     assert len(matches[0].sum_scores) == 5
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu1"] == 100
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu2"] == 20
@@ -268,7 +263,7 @@ def test_success_with_chip_init():
     group_repository.create(dummy_group)
     group_repository.update_settings(
         "G0123456789abcdefghijklmnopqrstu1",
-        EmbeddedGroupSettings(chip_rate=50),
+        EmbeddedGroupSettings(chip_rate=1),
     )
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
@@ -311,7 +306,7 @@ def test_success_with_chip():
     )
     group_repository.update_settings(
         "G0123456789abcdefghijklmnopqrstu1",
-        EmbeddedGroupSettings(chip_rate=50),
+        EmbeddedGroupSettings(rate=5, chip_rate=1),
     )
     for dummy_user in dummy_users:
         user_repository.create(dummy_user)
@@ -342,20 +337,15 @@ def test_success_with_chip():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "【対戦結果】 \ntest_user1: 150pt (+100(+3枚))\ntest_user2: -150pt (+20(-3枚))\n"
-        + "test_user3: 0pt (-40(0枚))\ntest_user4: 0pt (-40(0枚))\ntest_user5: 0pt (-40(0枚))"
+        == "【対戦結果】 \ntest_user1: 5150pt (+100 / チップ+3枚)\ntest_user2: 850pt (+20 / チップ-3枚)\n"
+        + "test_user3: -2000pt (-40 / チップ0枚)\ntest_user4: -2000pt (-40 / チップ0枚)\ntest_user5: -2000pt (-40 / チップ0枚)"
     )
     groups = group_repository.find({"line_group_id": dummy_group.line_group_id})
     assert groups[0].mode == GroupMode.wait.value
     assert groups[0].active_match_id is None
     matches = match_repository.find()
     assert not matches[0].is_deleted
-    assert len(matches[0].chip_prices) == 5
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu1"] == 150
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu2"] == -150
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu3"] == 0
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu4"] == 0
-    assert matches[0].chip_prices["U0123456789abcdefghijklmnopqrstu5"] == 0
+    assert matches[0].chip_prices == {}
     assert len(matches[0].sum_scores) == 5
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu1"] == 100
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu2"] == 20
@@ -363,17 +353,17 @@ def test_success_with_chip():
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu4"] == -40
     assert matches[0].sum_scores["U0123456789abcdefghijklmnopqrstu5"] == -40
     assert len(matches[0].sum_prices) == 5
-    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu1"] == 0
-    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu2"] == 0
-    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu3"] == 0
-    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu4"] == 0
-    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu5"] == 0
+    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu1"] == 5000
+    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu2"] == 1000
+    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu3"] == -2000
+    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu4"] == -2000
+    assert matches[0].sum_prices["U0123456789abcdefghijklmnopqrstu5"] == -2000
     assert len(matches[0].sum_prices_with_chip) == 5
-    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu1"] == 150
-    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu2"] == -150
-    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu3"] == 0
-    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu4"] == 0
-    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu5"] == 0
+    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu1"] == 5150
+    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu2"] == 850
+    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu3"] == -2000
+    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu4"] == -2000
+    assert matches[0].sum_prices_with_chip["U0123456789abcdefghijklmnopqrstu5"] == -2000
 
 
 def test_success_without_active_match():

--- a/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
+++ b/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
@@ -50,7 +50,7 @@ def test_execute():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "[設定]\n4人麻雀\nレート: 点3\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: 1枚1点\n計算方法: 3万点以下切り上げ/以上切り捨て\n単位: pt"
+        == "[設定]\n4人麻雀\nレート: 点3\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: あり(1枚=1点)\n計算方法: 3万点以下切り上げ/以上切り捨て\n単位: pt"
     )
     assert len(reply_service.buttons) == 1
     assert isinstance(reply_service.buttons[0], TemplateMessage)
@@ -74,7 +74,7 @@ def test_execute_no_settings():
     assert len(reply_service.texts) == 1
     assert (
         reply_service.texts[0].text
-        == "[設定]\n4人麻雀\nレート: 点0\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: 1枚0点\n計算方法: 五捨六入\n単位: pt"
+        == "[設定]\n4人麻雀\nレート: 点0\n順位点: 1着20/2着10/3着-10/4着-20\n飛び賞: 10点\nチップ: なし\n計算方法: 五捨六入\n単位: pt"
     )
     assert len(reply_service.buttons) == 1
     assert isinstance(reply_service.buttons[0], TemplateMessage)

--- a/tests/use_cases/group_line/test__reply_match_by_index_use_case.py
+++ b/tests/use_cases/group_line/test__reply_match_by_index_use_case.py
@@ -165,7 +165,7 @@ def test_execute():
     assert len(reply_service.texts) == 2
     assert (
         reply_service.texts[0].text
-        == "第2回\n2010年01月01日\ntest_user1: 1000pt (+30(+10枚))\ntest_user2: 1800pt (+60(0枚))\ntest_user3: -1800pt (-60(0枚))\ntest_user4: -400pt (-10(-10枚))\ntest_user5: -300pt (-10(0枚))\n友達未登録: -300pt (-10(0枚))"
+        == "第2回\n2010年01月01日\ntest_user1: 1000pt (+30 / チップ+10枚)\ntest_user2: 1800pt (+60 / チップ0枚)\ntest_user3: -1800pt (-60 / チップ0枚)\ntest_user4: -400pt (-10 / チップ-10枚)\ntest_user5: -300pt (-10 / チップ0枚)\n友達未登録: -300pt (-10 / チップ0枚)"
     )
     assert (
         reply_service.texts[1].text

--- a/tests/use_cases/group_line/test__update_group_settings_use_case.py
+++ b/tests/use_cases/group_line/test__update_group_settings_use_case.py
@@ -92,14 +92,14 @@ def test_execute_chip_rate():
     _setup()
     use_case = UpdateGroupSettingsUseCase()
 
-    use_case.execute("チップ", "100")
+    use_case.execute("チップ", "1")
 
     assert len(reply_service.texts) == 1
-    assert reply_service.texts[0].text == "[チップ]を[1枚100円]に変更しました。"
+    assert reply_service.texts[0].text == "[チップ]を[あり(1枚=1点)]に変更しました。"
     s = _get_settings()
     assert s.rate == 0
     assert s.ranking_prize == [20, 10, -10, -20]
-    assert s.chip_rate == 100
+    assert s.chip_rate == 1
     assert s.tobi_prize == 10
     assert s.num_of_players == 4
     assert s.rounding_method == 0
@@ -189,7 +189,7 @@ def test_execute_invalid_key():
         ("レート", "6", "[レート]を[6]に変更できません"),
         ("順位点", "10,20,30", "[順位点]を[10,20,30]に変更できません"),
         ("順位点", "10,20,30,40,50", "[順位点]を[10,20,30,40,50]に変更できません"),
-        ("チップ", "1", "[チップ]を[1]に変更できません"),
+        ("チップ", "2", "[チップ]を[2]に変更できません"),
         ("飛び賞", "1", "[飛び賞]を[1]に変更できません"),
         ("人数", "2", "[人数]を[2]に変更できません"),
         ("端数計算方法", "5", "[端数計算方法]を[5]に変更できません"),


### PR DESCRIPTION
## Summary
- チップ計算ロジック刷新: チップ枚数を累計ポイントに加算してからレートを掛ける方式に変更
  - 旧: `chip_price = chip_count * chip_rate` → レート精算に別途加算
  - 新: `total = (converted_score + chip_count) * rate`
- チップ設定を「なし / あり(1枚=1点)」の2択に簡素化
- チップなしの場合、結果表示からチップ情報を省略

## Test plan
- [ ] `_setting` → チップが「なし / あり(1枚=1点)」の2択
- [ ] チップなしで清算 → チップ枚数表示なし
- [ ] チップありで清算 → `(score + chip) * rate` で計算される
- [ ] 既存テスト 564 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)