### PR TITLE
fix: auto-start input のレース条件対策にタイムウィンドウを追加

### DIFF
--- a/src/domain_model/entities/group.py
+++ b/src/domain_model/entities/group.py
@@ -23,6 +23,7 @@ class Group:
     active_match_id: ObjectId = field(default=None)
     settings: Optional[EmbeddedGroupSettings] = field(default=None)
     last_command: str = field(default=None)
+    last_command_at: Optional[datetime] = field(default=None)
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
     _id: ObjectId = field(default=None)

--- a/src/repositories/group_repository.py
+++ b/src/repositories/group_repository.py
@@ -82,6 +82,7 @@ class GroupRepository(IGroupRepository):
             active_match_id=record.get("active_match_id"),
             settings=settings,
             last_command=record.get("last_command"),
+            last_command_at=record.get("last_command_at"),
             created_at=record.get("created_at"),
             updated_at=record.get("updated_at"),
             _id=record.get("_id"),

--- a/src/routing_by_text_in_group_line.py
+++ b/src/routing_by_text_in_group_line.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from enum import Enum
 
 from application_service import (
@@ -8,6 +9,9 @@ from domain_model.entities.group import GroupMode
 from domain_service import (
     group_service,
 )
+
+# _input コマンドとほぼ同時に送られた整数を拾うための許容時間（秒）
+_AUTO_INPUT_WINDOW_SECONDS = 5
 from use_cases.common_line.reply_fortune_use_case import ReplyFortuneUseCase
 from use_cases.common_line.reply_rank_histogram_use_case import (
     ReplyRankHistogramUseCase,
@@ -143,18 +147,30 @@ def routing_by_text_in_group_line():
 
 
 def _save_last_command(command: str):
-    """グループの last_command を更新"""
+    """グループの last_command を更新（タイムスタンプ付き）"""
     group_id = request_info_service.req_line_group_id
     group = group_service.find_one_by_line_group_id(group_id)
     if group is not None:
         group.last_command = command
+        group.last_command_at = datetime.now()
         group_service.update(group)
 
 
 def _should_auto_start_input(group_id: str) -> bool:
-    """Wait モードで数値テキストが来たとき、直前コマンドが input なら True"""
+    """Wait モードで数値テキストが来たとき、_input が直近に実行されていれば True。
+
+    _input コマンドと整数メッセージがほぼ同時に送られた場合（並行 Worker で
+    整数側が先に処理されるケース）に、整数を拾うためのレース条件対策。
+    タイムウィンドウ（_AUTO_INPUT_WINDOW_SECONDS 秒）を超えた場合は発動しない。
+    """
     group = group_service.find_one_by_line_group_id(group_id)
     if group is None or group.last_command != RCommands.input.name:
+        return False
+    # タイムウィンドウチェック
+    if group.last_command_at is None:
+        return False
+    elapsed = datetime.now() - group.last_command_at
+    if elapsed > timedelta(seconds=_AUTO_INPUT_WINDOW_SECONDS):
         return False
     # メッセージが数値（点数入力）かどうか判定
     message = request_info_service.message

--- a/src/routing_by_text_in_group_line.py
+++ b/src/routing_by_text_in_group_line.py
@@ -147,7 +147,7 @@ def routing_by_text_in_group_line():
 
 
 def _save_last_command(command: str):
-    """グループの last_command を更新（タイムスタンプ付き）"""
+    """グループの last_command を更新 (タイムスタンプ付き)."""
     group_id = request_info_service.req_line_group_id
     group = group_service.find_one_by_line_group_id(group_id)
     if group is not None:
@@ -159,9 +159,9 @@ def _save_last_command(command: str):
 def _should_auto_start_input(group_id: str) -> bool:
     """Wait モードで数値テキストが来たとき、_input が直近に実行されていれば True。
 
-    _input コマンドと整数メッセージがほぼ同時に送られた場合（並行 Worker で
-    整数側が先に処理されるケース）に、整数を拾うためのレース条件対策。
-    タイムウィンドウ（_AUTO_INPUT_WINDOW_SECONDS 秒）を超えた場合は発動しない。
+    _input コマンドと整数メッセージがほぼ同時に送られた場合 (並行 Worker で
+    整数側が先に処理されるケース) に、整数を拾うためのレース条件対策。
+    タイムウィンドウ (_AUTO_INPUT_WINDOW_SECONDS 秒) を超えた場合は発動しない。
     """
     group = group_service.find_one_by_line_group_id(group_id)
     if group is None or group.last_command != RCommands.input.name:

--- a/src/use_cases/group_line/start_input_use_case.py
+++ b/src/use_cases/group_line/start_input_use_case.py
@@ -54,7 +54,7 @@ class StartInputUseCase:
 
     @staticmethod
     def _cleanup_sim_hanchan(group) -> None:
-        """sim モードの半荘を削除し、active_hanchan_id をリセットする。"""
+        """Sim モードの半荘を削除し、active_hanchan_id をリセットする。"""
         active_match = match_service.find_one_by_id(group.active_match_id)
         if active_match is None:
             return

--- a/tests/domain_service/group_service/test_group_service_update.py
+++ b/tests/domain_service/group_service/test_group_service_update.py
@@ -36,6 +36,7 @@ def test_ok(mocker):
             "active_match_id": None,
             "settings": None,
             "last_command": None,
+            "last_command_at": None,
             "created_at": datetime(2010,1,2,3,4,0,0),
             "updated_at": datetime(2010,1,2,3,4,0,0),
         },

--- a/tests/scenarios/test_error_recovery_flow.py
+++ b/tests/scenarios/test_error_recovery_flow.py
@@ -45,7 +45,7 @@ def test_error_recovery_flow():
     _set_group_request()
     StartInputUseCase().execute()
 
-    from repositories import group_repository  # noqa: PLC0415
+    from repositories import group_repository
     groups = group_repository.find({"line_group_id": GROUP_ID})
     match_id = groups[0].active_match_id
 

--- a/tests/use_cases/group_line/test__auto_start_input.py
+++ b/tests/use_cases/group_line/test__auto_start_input.py
@@ -15,7 +15,6 @@ from domain_model.entities.user import User, UserMode
 from line_models.event import Event
 from repositories import (
     group_repository,
-    hanchan_repository,
     match_repository,
     user_repository,
 )

--- a/tests/use_cases/group_line/test__auto_start_input.py
+++ b/tests/use_cases/group_line/test__auto_start_input.py
@@ -1,0 +1,157 @@
+"""_input コマンドと整数メッセージの並行処理（レース条件対策）テスト。
+
+- _input 直後（5秒以内）に整数が来た場合 → auto-start input で処理される
+- _input から5秒超過後に整数が来た場合 → auto-start しない
+- last_command が input 以外の場合 → auto-start しない
+"""
+from datetime import datetime, timedelta
+
+from application_service import (
+    reply_service,
+    request_info_service,
+)
+from domain_model.entities.group import Group, GroupMode
+from domain_model.entities.user import User, UserMode
+from line_models.event import Event
+from repositories import (
+    group_repository,
+    hanchan_repository,
+    match_repository,
+    user_repository,
+)
+from routing_by_text_in_group_line import routing_by_text_in_group_line
+
+LINE_GROUP_ID = "G0123456789abcdefghijklmnopqrstu1"
+USER_ID = "U0123456789abcdefghijklmnopqrstu1"
+
+
+def _make_event(text: str) -> Event:
+    return Event(
+        type="message",
+        source_type="group",
+        user_id=USER_ID,
+        group_id=LINE_GROUP_ID,
+        message_type="text",
+        text=text,
+    )
+
+
+def _setup_user():
+    user_repository.create(
+        User(
+            line_user_name="test_user",
+            line_user_id=USER_ID,
+            mode=UserMode.wait.value,
+            _id=1,
+        ),
+    )
+
+
+def test_auto_start_within_window():
+    """_input 直後（5秒以内）に整数が送られた場合、auto-start で input になり点数が処理される。"""
+    _setup_user()
+    # _input が直前に実行された状態をシミュレート
+    group_repository.create(
+        Group(
+            line_group_id=LINE_GROUP_ID,
+            mode=GroupMode.wait.value,
+            last_command="input",
+            last_command_at=datetime.now(),  # 直前
+            _id=1,
+        ),
+    )
+
+    # 整数メッセージを送信
+    request_info_service.set_req_info(event=_make_event("35000"))
+    routing_by_text_in_group_line()
+
+    # auto-start が発動し、input モードで点数が処理される
+    groups = group_repository.find({"line_group_id": LINE_GROUP_ID})
+    assert groups[0].mode == GroupMode.input.value
+
+    # match と hanchan が作成されている
+    matches = match_repository.find()
+    assert len(matches) >= 1
+
+
+def test_no_auto_start_after_window():
+    """_input から5秒超過後に整数が送られた場合、auto-start しない。"""
+    _setup_user()
+    group_repository.create(
+        Group(
+            line_group_id=LINE_GROUP_ID,
+            mode=GroupMode.wait.value,
+            last_command="input",
+            last_command_at=datetime.now() - timedelta(seconds=10),  # 10秒前
+            _id=1,
+        ),
+    )
+
+    request_info_service.set_req_info(event=_make_event("35000"))
+    routing_by_text_in_group_line()
+
+    # auto-start は発動しない（wait のまま）
+    groups = group_repository.find({"line_group_id": LINE_GROUP_ID})
+    assert groups[0].mode == GroupMode.wait.value
+    # メッセージも出ない（wait モードで整数は無視される）
+    assert len(reply_service.texts) == 0
+
+
+def test_no_auto_start_without_last_command():
+    """last_command が input 以外の場合、auto-start しない。"""
+    _setup_user()
+    group_repository.create(
+        Group(
+            line_group_id=LINE_GROUP_ID,
+            mode=GroupMode.wait.value,
+            last_command="exit",
+            last_command_at=datetime.now(),
+            _id=1,
+        ),
+    )
+
+    request_info_service.set_req_info(event=_make_event("35000"))
+    routing_by_text_in_group_line()
+
+    groups = group_repository.find({"line_group_id": LINE_GROUP_ID})
+    assert groups[0].mode == GroupMode.wait.value
+
+
+def test_no_auto_start_without_timestamp():
+    """last_command_at が None の場合（旧データ）、auto-start しない。"""
+    _setup_user()
+    group_repository.create(
+        Group(
+            line_group_id=LINE_GROUP_ID,
+            mode=GroupMode.wait.value,
+            last_command="input",
+            last_command_at=None,
+            _id=1,
+        ),
+    )
+
+    request_info_service.set_req_info(event=_make_event("35000"))
+    routing_by_text_in_group_line()
+
+    groups = group_repository.find({"line_group_id": LINE_GROUP_ID})
+    assert groups[0].mode == GroupMode.wait.value
+
+
+def test_no_auto_start_for_non_numeric():
+    """数値でないメッセージでは auto-start しない。"""
+    _setup_user()
+    group_repository.create(
+        Group(
+            line_group_id=LINE_GROUP_ID,
+            mode=GroupMode.wait.value,
+            last_command="input",
+            last_command_at=datetime.now(),
+            _id=1,
+        ),
+    )
+
+    request_info_service.set_req_info(event=_make_event("こんにちは"))
+    routing_by_text_in_group_line()
+
+    groups = group_repository.find({"line_group_id": LINE_GROUP_ID})
+    assert groups[0].mode == GroupMode.wait.value

--- a/tests/use_cases/group_line/test__sim_to_input_transition.py
+++ b/tests/use_cases/group_line/test__sim_to_input_transition.py
@@ -83,8 +83,9 @@ def _setup_group_with_match_and_hanchan(mode=GroupMode.wait.value):
 
 
 def test_sim_to_input_cleans_up_sim_hanchan():
-    """sim → input 切り替え時に sim 用半荘が削除され、
-    新しい空の半荘で input モードが開始される。"""
+    """Sim → input 切り替え時に sim 用半荘が削除され、
+    新しい空の半荘で input モードが開始される。
+    """
     _setup_users()
     request_info_service.set_req_info(event=sim_event)
 
@@ -133,7 +134,7 @@ def test_sim_to_input_cleans_up_sim_hanchan():
 
 
 def test_input_to_sim_does_not_reuse_input_hanchan():
-    """input → sim 切り替え時に、input の途中データが sim に混入しない。"""
+    """Input → sim 切り替え時に、input の途中データが sim に混入しない。"""
     _setup_users()
     _setup_group_with_match_and_hanchan(mode=GroupMode.input.value)
 
@@ -155,7 +156,7 @@ def test_input_to_sim_does_not_reuse_input_hanchan():
 
 
 def test_input_to_sim_to_input_no_data_leak():
-    """input → sim → input の往復で、sim のデータが input に漏れない。"""
+    """Input → sim → input の往復で、sim のデータが input に漏れない。"""
     _setup_users()
     _setup_group_with_match_and_hanchan(mode=GroupMode.input.value)
 

--- a/tests/use_cases/group_line/test__start_sim_use_case.py
+++ b/tests/use_cases/group_line/test__start_sim_use_case.py
@@ -47,7 +47,7 @@ def test_already_sim_mode():
 
 
 def test_new_match_and_hanchan():
-    """match も hanchan もない場合、両方新規作成してsimモードになる。"""
+    """Match も hanchan もない場合、両方新規作成してsimモードになる。"""
     request_info_service.set_req_info(event=dummy_event)
     group_repository.create(
         Group(line_group_id="G0123456789abcdefghijklmnopqrstu1", _id=1),
@@ -69,7 +69,8 @@ def test_new_match_and_hanchan():
 
 def test_always_creates_fresh_hanchan():
     """既存の active hanchan があっても、sim 用に新しい半荘を作成する。
-    これにより input モードの途中入力が sim に混入しない。"""
+    これにより input モードの途中入力が sim に混入しない。
+    """
     request_info_service.set_req_info(event=dummy_event)
     existing_hanchan = Hanchan(
         line_group_id="G0123456789abcdefghijklmnopqrstu1",


### PR DESCRIPTION
## Summary
- `_input` コマンド実行後に `last_command` が永続化し、半荘完了後でも整数入力で勝手に input モードが始まるバグを修正
- `Group` エンティティに `last_command_at` タイムスタンプを追加
- `_should_auto_start_input` に5秒のタイムウィンドウチェックを追加し、`_input` コマンドから5秒以内の整数メッセージのみ auto-start を発動するように変更

## 背景
元の要望: `_input` と整数メッセージがほぼ同時に送られた場合 (並行 Worker で整数側が先に処理されるケース) に、整数を拾いたい。しかし `last_command` がクリアされずに残り続けるため、半荘完了後の整数入力でも auto-start が発動していた。

## Test plan
- [x] `_input` 直後 (5秒以内) の整数 → auto-start 発動
- [x] `_input` から5秒超過後の整数 → auto-start しない
- [x] `last_command` が input 以外 → auto-start しない
- [x] `last_command_at` が None (旧データ) → auto-start しない
- [x] 数値でないメッセージ → auto-start しない
- [x] 既存テスト 649 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)