### PR TITLE
feat: レート設定を Quick Reply で一覧表示に変更

### DIFF
--- a/src/application_service/reply_service.py
+++ b/src/application_service/reply_service.py
@@ -205,7 +205,8 @@ class ReplyService(IReplyService):
                     ),
                 ),
             )
-        elif key == "レート":
+        elif key in {"レート", "高レート"}:
+            # "高レート" は後方互換のため残す（過去チャット履歴の "点4~" ボタン対応）
             self.texts.append(
                 TextMessage(
                     text="レートを選んでください",

--- a/src/application_service/reply_service.py
+++ b/src/application_service/reply_service.py
@@ -205,8 +205,7 @@ class ReplyService(IReplyService):
                     ),
                 ),
             )
-        elif key in {"レート", "高レート"}:
-            # "高レート" は後方互換のため残す（過去チャット履歴の "点4~" ボタン対応）
+        elif key == "レート":
             self.texts.append(
                 TextMessage(
                     text="レートを選んでください",

--- a/src/application_service/reply_service.py
+++ b/src/application_service/reply_service.py
@@ -206,51 +206,28 @@ class ReplyService(IReplyService):
                 ),
             )
         elif key == "レート":
-            self.buttons.append(
-                TemplateMessage(
-                    alt_text="レート設定",
-                    template=ButtonsTemplate(
-                        title="レート変更",
-                        text="レートを選んでください",
-                        actions=[
-                            PostbackAction(
-                                label=f"点{i}",
-                                display_text=f"点{i}",
-                                data=f"_update_config レート {i}",
-                            )
-                            for i in range(1, 4)
+            self.texts.append(
+                TextMessage(
+                    text="レートを選んでください",
+                    quick_reply=QuickReply(
+                        items=[
+                            QuickReplyItem(
+                                action=PostbackAction(
+                                    label="なし",
+                                    display_text="なし",
+                                    data="_update_config レート 0",
+                                ),
+                            ),
                         ]
                         + [
-                            PostbackAction(
-                                label="点4~",
-                                display_text="点4~",
-                                data="_setting 高レート",
-                            ),
-                        ],
-                    ),
-                ),
-            )
-        elif key == "高レート":
-            self.buttons.append(
-                TemplateMessage(
-                    alt_text="高レート設定",
-                    template=ButtonsTemplate(
-                        title="レート変更",
-                        text="レートを選んでください",
-                        actions=[
-                            PostbackAction(
-                                label=f"点{i}",
-                                display_text=f"点{i}",
-                                data=f"_update_config レート {i}",
+                            QuickReplyItem(
+                                action=PostbackAction(
+                                    label=f"点{i}",
+                                    display_text=f"点{i}",
+                                    data=f"_update_config レート {i}",
+                                ),
                             )
-                            for i in [4, 5, 10]
-                        ]
-                        + [
-                            PostbackAction(
-                                label="点1~3",
-                                display_text="点1~3",
-                                data="_setting レート",
-                            ),
+                            for i in [1, 2, 3, 4, 5, 10]
                         ],
                     ),
                 ),

--- a/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
+++ b/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
@@ -37,20 +37,6 @@ def test_success_key_rate():
     assert len(reply_service.texts[0].quick_reply.items) == 7
 
 
-def test_success_key_high_rate_legacy():
-    """後方互換: 過去チャット履歴の '高レート' ボタンも新しい Quick Reply を返す。"""
-    # Arrange
-    reply_service = ReplyService()
-
-    # Act
-    reply_service.add_settings_menu("高レート")
-
-    # Assert
-    assert len(reply_service.texts) == 1
-    assert reply_service.texts[0].quick_reply is not None
-    assert len(reply_service.texts[0].quick_reply.items) == 7
-
-
 def test_success_key_chip():
     # Arrange
     reply_service = ReplyService()

--- a/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
+++ b/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
@@ -37,6 +37,20 @@ def test_success_key_rate():
     assert len(reply_service.texts[0].quick_reply.items) == 7
 
 
+def test_success_key_high_rate_legacy():
+    """後方互換: 過去チャット履歴の '高レート' ボタンも新しい Quick Reply を返す。"""
+    # Arrange
+    reply_service = ReplyService()
+
+    # Act
+    reply_service.add_settings_menu("高レート")
+
+    # Assert
+    assert len(reply_service.texts) == 1
+    assert reply_service.texts[0].quick_reply is not None
+    assert len(reply_service.texts[0].quick_reply.items) == 7
+
+
 def test_success_key_chip():
     # Arrange
     reply_service = ReplyService()

--- a/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
+++ b/tests/application_service/reply_service/test_reply_service_add_settings_menu.py
@@ -30,19 +30,11 @@ def test_success_key_rate():
     # Act
     reply_service.add_settings_menu("レート")
 
-    # Assert
-    assert len(reply_service.buttons) == 1
-
-
-def test_success_key_high_rate():
-    # Arrange
-    reply_service = ReplyService()
-
-    # Act
-    reply_service.add_settings_menu("高レート")
-
-    # Assert
-    assert len(reply_service.buttons) == 1
+    # Assert: Quick Reply で返るため texts に追加される
+    assert len(reply_service.texts) == 1
+    assert reply_service.texts[0].quick_reply is not None
+    # なし + 点1~5 + 点10 = 7 items
+    assert len(reply_service.texts[0].quick_reply.items) == 7
 
 
 def test_success_key_chip():

--- a/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
+++ b/tests/use_cases/group_line/test__reply_group_settings_menu_use_case.py
@@ -83,8 +83,6 @@ def test_execute_no_settings():
 @pytest.fixture(
     params=[
         ("メニュー2"),
-        ("レート"),
-        ("高レート"),
         ("順位点"),
         ("飛び賞"),
         ("端数計算方法"),
@@ -97,12 +95,7 @@ def case1(request) -> Tuple[int]:
 
 
 def test_execute_(case1):
-    # 目的: test_execute_ の挙動を検証する。
-    # 入力: case1
-    # 入力の意図: 指定入力・状態に対するユースケースの出力/副作用を確認する。
-    # 想定出力: reply_service.texts の件数が 0 件 / reply_service.buttons の件数が 1 件 / reply_service.buttons[0] が TemplateSendMessage 型
-    # reply_service: buttons, texts
-    # DB操作: なし
+    # 目的: ButtonsTemplate で返る設定メニューの挙動を検証する。
     # Arrange
     request_info_service.set_req_info(event=dummy_event)
     use_case = ReplyGroupSettingsMenuUseCase()
@@ -114,3 +107,15 @@ def test_execute_(case1):
     assert len(reply_service.texts) == 0
     assert len(reply_service.buttons) == 1
     assert isinstance(reply_service.buttons[0], TemplateMessage)
+
+
+def test_execute_rate():
+    """レート設定は Quick Reply で返る。"""
+    request_info_service.set_req_info(event=dummy_event)
+    use_case = ReplyGroupSettingsMenuUseCase()
+
+    use_case.execute("レート")
+
+    assert len(reply_service.texts) == 1
+    assert reply_service.texts[0].quick_reply is not None
+    assert len(reply_service.buttons) == 0


### PR DESCRIPTION
## Summary
- レート設定の2段階 ButtonsTemplate UI (点1-3 / 点4~) を Quick Reply に変更
- 全レート選択肢 (なし, 点1-5, 点10) が横スクロールで1画面に表示される
- 点5 を選ぶのに2タップ必要だった問題を解消

## Test plan
- [x] `_setting` → レート → Quick Reply で全選択肢が表示される
- [x] 各レートを選択 → 正常に設定変更される
- [x] 「高レート」メニューの参照を削除
- [x] 既存テスト 647 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)