### PR TITLE
fix: _inputコマンド直後の点数入力レース条件を修正

### DIFF
--- a/src/use_cases/group_line/add_point_by_text_use_case.py
+++ b/src/use_cases/group_line/add_point_by_text_use_case.py
@@ -31,7 +31,7 @@ class AddPointByTextUseCase:
             reply_service.add_message("グループが登録されていません。招待し直してください。")
             return
         active_match = match_service.find_one_by_id(group.active_match_id)
-        if active_match.active_hanchan_id is None:
+        if active_match is None or active_match.active_hanchan_id is None:
             return
         hanchan = hanchan_service.add_or_drop_raw_score(
             hanchan_id=active_match.active_hanchan_id,

--- a/src/use_cases/group_line/start_input_use_case.py
+++ b/src/use_cases/group_line/start_input_use_case.py
@@ -25,8 +25,15 @@ class StartInputUseCase:
             reply_service.add_message("すでに入力モードです。")
             return
 
+        original_mode = group.mode
+
+        # レース条件対策: 点数入力が _input コマンドと同時に送られた場合でも
+        # 並行ワーカーが input モードを認識できるよう、最初に mode を更新する
+        group.mode = GroupMode.input.value
+        group_service.update(group)
+
         # sim モードからの切り替え時は sim 用半荘をクリーンアップ
-        if group.mode == GroupMode.sim.value:
+        if original_mode == GroupMode.sim.value:
             self._cleanup_sim_hanchan(group)
 
         # group の active match を取得、なければ作成
@@ -34,6 +41,7 @@ class StartInputUseCase:
         if active_match is None:
             active_match = match_service.create_with_line_group_id(group.line_group_id)
             group.active_match_id = active_match._id
+            group_service.update(group)
 
         # match の active hanchan を取得、なければ作成
         active_hanchan = hanchan_service.find_one_by_id(active_match.active_hanchan_id)
@@ -44,9 +52,6 @@ class StartInputUseCase:
             active_match.active_hanchan_id = active_hanchan._id
             match_service.update(active_match)
 
-        group.mode = GroupMode.input.value
-        group_service.update(group)
-
         hanchans = hanchan_service.find_all_archived_by_match_id(active_match._id)
         reply_service.add_message(
             f"第{len(hanchans) + 1}回戦お疲れ様です。各自点数を入力してください。\n(同点の場合は上家が高くなるように数点追加してください)",
@@ -54,7 +59,7 @@ class StartInputUseCase:
 
     @staticmethod
     def _cleanup_sim_hanchan(group) -> None:
-        """sim モードの半荘を削除し、active_hanchan_id をリセットする。"""
+        """Sim モードの半荘を削除し、active_hanchan_id をリセットする。"""
         active_match = match_service.find_one_by_id(group.active_match_id)
         if active_match is None:
             return

--- a/tests/use_cases/group_line/test__start_input_use_case.py
+++ b/tests/use_cases/group_line/test__start_input_use_case.py
@@ -168,6 +168,38 @@ def test_execute_new_hanchan():
     assert len(hanchans) == 1
 
 
+def test_mode_updated_before_match_creation():
+    """mode が active_match_id より先に input に更新されることを確認する。
+
+    レース条件対策として group.mode = input を先に DB へ書き込むため、
+    match 作成後も group.mode と active_match_id が両方保存されている。
+    """
+    from unittest.mock import patch
+    from domain_service import group_service as gs
+
+    request_info_service.set_req_info(event=dummy_event)
+    use_case = StartInputUseCase()
+    for dummy_group in dummy_groups:
+        group_repository.create(dummy_group)
+
+    update_calls = []
+    original_update = gs.update
+
+    def tracking_update(group):
+        update_calls.append(group.mode)
+        return original_update(group)
+
+    with patch.object(gs, "update", side_effect=tracking_update):
+        use_case.execute()
+
+    # 1回目の update で mode が input に変わっていること
+    assert update_calls[0] == GroupMode.input.value
+    # 最終的に active_match_id も保存されていること
+    groups = group_repository.find({"line_group_id": "G0123456789abcdefghijklmnopqrstu1"})
+    assert groups[0].mode == GroupMode.input.value
+    assert groups[0].active_match_id is not None
+
+
 def test_execute_with_hanchan():
     # 目的: test_execute_with_hanchan の挙動を検証する。
     # 入力: なし


### PR DESCRIPTION
## 概要

`_input` コマンドと点数入力が同時に送られた際、並行ワーカーが点数メッセージを先に処理すると wait モードと判定されてしまう問題を修正。

## 原因

`StartInputUseCase.execute()` 内でモード変更 (`group.mode = input`) が match/hanchan の作成処理より後に行われていたため、並行ワーカーが処理する間は DB がまだ wait モードのままだった。

## 修正内容

`group.mode = GroupMode.input.value` + `group_service.update()` を処理の最初（バリデーション直後）に移動。
これにより、以降の match/hanchan 作成中も DB は input モードを返すようになる。

なお `_should_auto_start_input` の time window / `last_command_at` による複雑な回収アプローチは採用しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)