### PR TITLE
fix: _rankingでCloud RunのFileNotFoundErrorを修正

### DIFF
--- a/src/application_service/ranking_table_image_builder.py
+++ b/src/application_service/ranking_table_image_builder.py
@@ -39,7 +39,10 @@ class RankingTableImageBuilder:
     def _paste_profile_images(self, base: Image.Image, sorted_ids: list) -> None:
         scale = self.SCALE
         for i, line_id in enumerate(sorted_ids):
-            profile_image = Image.open(f"src/uploads/profile_image/{line_id}.jpeg")
+            profile_image_path = f"src/uploads/profile_image/{line_id}.jpeg"
+            if not os.path.exists(profile_image_path):
+                continue
+            profile_image = Image.open(profile_image_path)
             profile_image = profile_image.resize((50 * scale, 50 * scale))
             mask = Image.new("L", profile_image.size, 0)
             draw_mask = ImageDraw.Draw(mask)

--- a/src/application_service/ranking_table_image_builder.py
+++ b/src/application_service/ranking_table_image_builder.py
@@ -39,8 +39,8 @@ class RankingTableImageBuilder:
     def _paste_profile_images(self, base: Image.Image, sorted_ids: list) -> None:
         scale = self.SCALE
         for i, line_id in enumerate(sorted_ids):
-            profile_image_path = f"src/uploads/profile_image/{line_id}.jpeg"
-            if not os.path.exists(profile_image_path):
+            profile_image_path = Path(f"src/uploads/profile_image/{line_id}.jpeg")
+            if not profile_image_path.exists():
                 continue
             profile_image = Image.open(profile_image_path)
             profile_image = profile_image.resize((50 * scale, 50 * scale))

--- a/src/use_cases/group_line/reply_ranking_table_use_case.py
+++ b/src/use_cases/group_line/reply_ranking_table_use_case.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple
 
@@ -142,16 +143,18 @@ class ReplyRankingTableUseCase:
 
     def _fetch_profile_images(self, active_user_line_ids: List[str]) -> Dict[str, str]:
         display_name_dict = {}
+        os.makedirs("src/uploads/profile_image", exist_ok=True)
         for line_id in active_user_line_ids:
             profile = line_bot_api.get_profile(line_id)
+            display_name_dict[line_id] = profile.display_name
+            if not profile.picture_url:
+                continue
             request_methods = urllib3.PoolManager(
                 cert_reqs="CERT_REQUIRED", ca_certs=certifi.where(),
             )
             response = request_methods.request("GET", profile.picture_url)
-            f = open(f"src/uploads/profile_image/{line_id}.jpeg", "wb")
-            f.write(response.data)
-            f.close()
-            display_name_dict[line_id] = profile.display_name
+            with open(f"src/uploads/profile_image/{line_id}.jpeg", "wb") as f:
+                f.write(response.data)
         return display_name_dict
 
     def _aggregate_stats(self, matches, hanchans, user_hanchans, active_user_line_ids) -> _RankingStats:

--- a/src/use_cases/group_line/reply_ranking_table_use_case.py
+++ b/src/use_cases/group_line/reply_ranking_table_use_case.py
@@ -148,6 +148,7 @@ class ReplyRankingTableUseCase:
             profile = line_bot_api.get_profile(line_id)
             display_name_dict[line_id] = profile.display_name
             if not profile.picture_url:
+                Path(f"src/uploads/profile_image/{line_id}.jpeg").unlink(missing_ok=True)
                 continue
             request_methods = urllib3.PoolManager(
                 cert_reqs="CERT_REQUIRED", ca_certs=certifi.where(),

--- a/src/use_cases/group_line/reply_ranking_table_use_case.py
+++ b/src/use_cases/group_line/reply_ranking_table_use_case.py
@@ -1,6 +1,6 @@
 import logging
-import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 import certifi
@@ -143,7 +143,7 @@ class ReplyRankingTableUseCase:
 
     def _fetch_profile_images(self, active_user_line_ids: List[str]) -> Dict[str, str]:
         display_name_dict = {}
-        os.makedirs("src/uploads/profile_image", exist_ok=True)
+        Path("src/uploads/profile_image").mkdir(parents=True, exist_ok=True)
         for line_id in active_user_line_ids:
             profile = line_bot_api.get_profile(line_id)
             display_name_dict[line_id] = profile.display_name


### PR DESCRIPTION
## 概要

_ranking コマンド実行時の2つのシステムエラーを修正。

## 修正内容

### 1. FileNotFoundError: profile_image ディレクトリが存在しない

`src/uploads/` が `.dockerignore` に記載されているため、Cloud Run コンテナ起動時に `src/uploads/profile_image/` ディレクトリが存在しない問題を修正。

- `Path.mkdir(parents=True, exist_ok=True)` でディレクトリを自動作成
- `picture_url` が None の場合は既存キャッシュファイルを `unlink(missing_ok=True)` で削除してスキップ
- 画像ファイルがない場合は貼り付けをスキップ (`Path.exists()` チェック追加)

### 2. OSError: cannot open resource (フォントファイル)

デフォルトの `FONT_FILE_PATH` が `NotoSerifCJK-Medium.ttc` になっていたが、`fonts-noto-cjk` パッケージは `Regular/Bold` のみ提供するため存在しないファイルを参照していた。

- デフォルトを `NotoSerifCJK-Regular.ttc` に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)