### PR TITLE
fix: uniform bucket-level access に非対応の blob.make_public() を削除

### DIFF
--- a/src/application_service/graph_service.py
+++ b/src/application_service/graph_service.py
@@ -84,7 +84,6 @@ class GraphService(IGraphService):
             bucket = client.bucket(env_var.GCS_BUCKET_NAME)
             blob = bucket.blob(blob_name)
             blob.upload_from_file(buf, content_type="image/png")
-            blob.make_public()
             return (blob.public_url, None)
         except Exception as err:
             logger.exception("GCS へのアップロードに失敗しました")

--- a/src/application_service/ranking_table_image_builder.py
+++ b/src/application_service/ranking_table_image_builder.py
@@ -69,7 +69,6 @@ class RankingTableImageBuilder:
             bucket = client.bucket(env_var.GCS_BUCKET_NAME)
             blob = bucket.blob(blob_name)
             blob.upload_from_file(buf, content_type="image/png")
-            blob.make_public()
             return (blob.public_url, None)
         except Exception as err:
             logger.exception("GCS へのアップロードに失敗しました")


### PR DESCRIPTION
## 概要

`_ranking` 等で「ランキングの画像アップロードに失敗しました」が発生していた問題を修正。

## 原因

`mahjong-manager-images` バケットは uniform bucket-level access が有効なため、`blob.make_public()`（レガシー ACL 操作）が `400 BadRequest` を返していた。

バケットには IAM で `allUsers:objectViewer` を付与済みのため `make_public()` は不要。

## 修正

`ranking_table_image_builder.py` と `graph_service.py` から `blob.make_public()` を削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)