### PR TITLE
feat: add score/chip editing and hanchan/match deletion (Web UI)

### DIFF
--- a/frontend/src/pages/MatchDetailPage.tsx
+++ b/frontend/src/pages/MatchDetailPage.tsx
@@ -1,19 +1,68 @@
-import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Pencil, Trash2 } from 'lucide-react'
 import api from '@/lib/api'
+import { useAuth } from '@/hooks/useAuth'
 import type { Match, Hanchan } from '@/types'
 
 interface MatchDetail extends Match {
   hanchans: Hanchan[]
 }
 
+interface EditScoresState {
+  hanchanId: string
+  scores: Record<string, number>
+  userNames: Record<string, string>
+}
+
+interface EditChipsState {
+  scores: Record<string, number>
+  userNames: Record<string, string>
+}
+
 export function MatchDetailPage() {
   const { matchId } = useParams<{ id: string; matchId: string }>()
+  const queryClient = useQueryClient()
+  const { user } = useAuth()
+
+  const [editScores, setEditScores] = useState<EditScoresState | null>(null)
+  const [editChips, setEditChips] = useState<EditChipsState | null>(null)
+  const [deleteHanchanId, setDeleteHanchanId] = useState<string | null>(null)
+  const [deleteMatchConfirm, setDeleteMatchConfirm] = useState(false)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
   const { data: match, isLoading } = useQuery({
     queryKey: ['matches', matchId],
     queryFn: () => api.get<MatchDetail>(`/matches/${matchId}`).then((r) => r.data),
+  })
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['matches', matchId] })
+
+  const deleteHanchanMutation = useMutation({
+    mutationFn: (hanchanId: string) => api.delete(`/hanchans/${hanchanId}`),
+    onSuccess: () => { setDeleteHanchanId(null); invalidate() },
+    onError: (e: unknown) => setErrorMsg(extractError(e) ?? '削除に失敗しました'),
+  })
+
+  const updateScoresMutation = useMutation({
+    mutationFn: ({ hanchanId, raw_scores }: { hanchanId: string; raw_scores: Record<string, number> }) =>
+      api.put(`/hanchans/${hanchanId}/scores`, { raw_scores }),
+    onSuccess: () => { setEditScores(null); invalidate() },
+    onError: (e: unknown) => setErrorMsg(extractError(e) ?? '更新に失敗しました'),
+  })
+
+  const deleteMatchMutation = useMutation({
+    mutationFn: () => api.delete(`/matches/${matchId}`),
+    onSuccess: () => { setDeleteMatchConfirm(false); window.history.back() },
+    onError: (e: unknown) => setErrorMsg(extractError(e) ?? '削除に失敗しました'),
+  })
+
+  const updateChipsMutation = useMutation({
+    mutationFn: (chip_scores: Record<string, number>) =>
+      api.put(`/matches/${matchId}/chips`, { chip_scores }),
+    onSuccess: () => { setEditChips(null); invalidate() },
+    onError: (e: unknown) => setErrorMsg(extractError(e) ?? '更新に失敗しました'),
   })
 
   if (isLoading) {
@@ -24,18 +73,100 @@ export function MatchDetailPage() {
     )
   }
 
+  const chipParticipants = match ? Object.keys(match.chip_scores ?? {}) : []
+  const hasChips = chipParticipants.length > 0
+
   return (
     <div className="px-4 py-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-1">
-        {match?.date ? formatDate(match.date) : '試合詳細'}
-      </h1>
-      <p className="text-muted-foreground text-sm mb-6">{match?.hanchan_count}半荘</p>
+      {/* ヘッダー */}
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold mb-1">
+            {match?.date ? formatDate(match.date) : '試合詳細'}
+          </h1>
+          <p className="text-muted-foreground text-sm">{match?.hanchan_count}半荘</p>
+        </div>
+        {user && (
+          <button
+            onClick={() => setDeleteMatchConfirm(true)}
+            className="flex items-center gap-1 px-3 py-1.5 text-sm text-red-500 border border-red-200 rounded-lg hover:bg-red-50 transition-colors"
+          >
+            <Trash2 size={14} />
+            対戦削除
+          </button>
+        )}
+      </div>
 
+      {/* エラー表示 */}
+      {errorMsg && (
+        <div className="mb-4 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">
+          {errorMsg}
+          <button className="ml-2 underline" onClick={() => setErrorMsg(null)}>閉じる</button>
+        </div>
+      )}
+
+      {/* チップ */}
+      {hasChips && (
+        <div className="mb-4 bg-white rounded-xl border border-border overflow-hidden">
+          <div className="px-4 py-2 bg-muted/50 border-b border-border flex items-center justify-between">
+            <p className="text-sm font-medium text-muted-foreground">チップ</p>
+            {user && (
+              <button
+                onClick={() => {
+                  const names: Record<string, string> = {}
+                  match?.hanchans.forEach((h) => h.scores.forEach((s) => { names[s.user_id] = s.user_name }))
+                  setEditChips({ scores: { ...(match?.chip_scores ?? {}) }, userNames: names })
+                }}
+                className="text-muted-foreground hover:text-primary"
+              >
+                <Pencil size={14} />
+              </button>
+            )}
+          </div>
+          <div className="px-4 py-3 flex flex-wrap gap-3">
+            {chipParticipants.map((uid) => {
+              const name = match?.hanchans.flatMap((h) => h.scores).find((s) => s.user_id === uid)?.user_name ?? uid
+              const count = match?.chip_scores?.[uid] ?? 0
+              return (
+                <span key={uid} className="text-sm">
+                  <span className="font-medium">{name}</span>
+                  <span className={`ml-1 font-semibold ${count >= 0 ? 'text-blue-600' : 'text-red-500'}`}>
+                    {count >= 0 ? '+' : ''}{count}
+                  </span>
+                </span>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* 半荘一覧 */}
       <div className="space-y-4">
         {match?.hanchans.map((hanchan, idx) => (
           <div key={hanchan.id} className="bg-white rounded-xl border border-border overflow-hidden">
-            <div className="px-4 py-2 bg-muted/50 border-b border-border">
+            <div className="px-4 py-2 bg-muted/50 border-b border-border flex items-center justify-between">
               <p className="text-sm font-medium text-muted-foreground">{idx + 1}半荘目</p>
+              {user && (
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => {
+                      const names: Record<string, string> = {}
+                      const scores: Record<string, number> = {}
+                      hanchan.scores.forEach((s) => { names[s.user_id] = s.user_name; scores[s.user_id] = s.score })
+                      setEditScores({ hanchanId: hanchan.id, scores, userNames: names })
+                    }}
+                    className="text-muted-foreground hover:text-primary"
+                  >
+                    <Pencil size={14} />
+                  </button>
+                  <button
+                    onClick={() => setDeleteHanchanId(hanchan.id)}
+                    className="text-muted-foreground hover:text-red-500"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              )}
             </div>
             <table className="w-full text-sm">
               <thead>
@@ -86,6 +217,154 @@ export function MatchDetailPage() {
           </div>
         ))}
       </div>
+
+      {/* 素点修正モーダル */}
+      {editScores && (
+        <Modal title="素点修正" onClose={() => setEditScores(null)}>
+          <div className="space-y-3">
+            {Object.entries(editScores.scores).map(([uid, score]) => (
+              <div key={uid} className="flex items-center gap-3">
+                <label className="w-24 text-sm font-medium truncate">
+                  {editScores.userNames[uid] ?? uid}
+                </label>
+                <input
+                  type="number"
+                  value={score}
+                  onChange={(e) =>
+                    setEditScores((prev) =>
+                      prev ? { ...prev, scores: { ...prev.scores, [uid]: Number(e.target.value) } } : prev,
+                    )
+                  }
+                  className="flex-1 px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 flex gap-2 justify-end">
+            <button
+              onClick={() => setEditScores(null)}
+              className="px-4 py-2 text-sm rounded-lg border border-border hover:bg-muted/50"
+            >
+              キャンセル
+            </button>
+            <button
+              disabled={updateScoresMutation.isPending}
+              onClick={() =>
+                updateScoresMutation.mutate({
+                  hanchanId: editScores.hanchanId,
+                  raw_scores: editScores.scores,
+                })
+              }
+              className="px-4 py-2 text-sm rounded-lg bg-primary text-white hover:bg-primary/90 disabled:opacity-50"
+            >
+              {updateScoresMutation.isPending ? '更新中...' : '更新'}
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {/* チップ修正モーダル */}
+      {editChips && (
+        <Modal title="チップ修正" onClose={() => setEditChips(null)}>
+          <div className="space-y-3">
+            {Object.entries(editChips.scores).map(([uid, count]) => (
+              <div key={uid} className="flex items-center gap-3">
+                <label className="w-24 text-sm font-medium truncate">
+                  {editChips.userNames[uid] ?? uid}
+                </label>
+                <input
+                  type="number"
+                  value={count}
+                  onChange={(e) =>
+                    setEditChips((prev) =>
+                      prev ? { ...prev, scores: { ...prev.scores, [uid]: Number(e.target.value) } } : prev,
+                    )
+                  }
+                  className="flex-1 px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 flex gap-2 justify-end">
+            <button
+              onClick={() => setEditChips(null)}
+              className="px-4 py-2 text-sm rounded-lg border border-border hover:bg-muted/50"
+            >
+              キャンセル
+            </button>
+            <button
+              disabled={updateChipsMutation.isPending}
+              onClick={() => updateChipsMutation.mutate(editChips.scores)}
+              className="px-4 py-2 text-sm rounded-lg bg-primary text-white hover:bg-primary/90 disabled:opacity-50"
+            >
+              {updateChipsMutation.isPending ? '更新中...' : '更新'}
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {/* 半荘削除確認 */}
+      {deleteHanchanId && (
+        <Modal title="半荘削除" onClose={() => setDeleteHanchanId(null)}>
+          <p className="text-sm text-muted-foreground">この半荘を削除します。元に戻せません。</p>
+          <div className="mt-4 flex gap-2 justify-end">
+            <button
+              onClick={() => setDeleteHanchanId(null)}
+              className="px-4 py-2 text-sm rounded-lg border border-border hover:bg-muted/50"
+            >
+              キャンセル
+            </button>
+            <button
+              disabled={deleteHanchanMutation.isPending}
+              onClick={() => deleteHanchanMutation.mutate(deleteHanchanId)}
+              className="px-4 py-2 text-sm rounded-lg bg-red-500 text-white hover:bg-red-600 disabled:opacity-50"
+            >
+              {deleteHanchanMutation.isPending ? '削除中...' : '削除'}
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {/* 対戦削除確認 */}
+      {deleteMatchConfirm && (
+        <Modal title="対戦削除" onClose={() => setDeleteMatchConfirm(false)}>
+          <p className="text-sm text-muted-foreground">
+            この対戦とすべての半荘データを削除します。元に戻せません。
+          </p>
+          <div className="mt-4 flex gap-2 justify-end">
+            <button
+              onClick={() => setDeleteMatchConfirm(false)}
+              className="px-4 py-2 text-sm rounded-lg border border-border hover:bg-muted/50"
+            >
+              キャンセル
+            </button>
+            <button
+              disabled={deleteMatchMutation.isPending}
+              onClick={() => deleteMatchMutation.mutate()}
+              className="px-4 py-2 text-sm rounded-lg bg-red-500 text-white hover:bg-red-600 disabled:opacity-50"
+            >
+              {deleteMatchMutation.isPending ? '削除中...' : '削除'}
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: React.ReactNode }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm bg-white rounded-2xl shadow-xl p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-base font-bold mb-4">{title}</h2>
+        {children}
+      </div>
     </div>
   )
 }
@@ -98,4 +377,8 @@ function formatDate(dateStr: string): string {
     day: 'numeric',
     weekday: 'short',
   })
+}
+
+function extractError(e: unknown): string | null {
+  return (e as { response?: { data?: { error?: string } } })?.response?.data?.error ?? null
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -24,6 +24,7 @@ export interface Match {
   date: string
   hanchan_count: number
   is_deleted: boolean
+  chip_scores?: Record<string, number>
 }
 
 export interface Hanchan {

--- a/src/apis/api/__init__.py
+++ b/src/apis/api/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 api_blueprint = Blueprint("api_blueprint", __name__, url_prefix="/api/v1")
 
-from . import groups, matches, rankings, users  # noqa: F401
+from . import edits, groups, matches, rankings, users  # noqa: F401

--- a/src/apis/api/edits.py
+++ b/src/apis/api/edits.py
@@ -1,0 +1,236 @@
+from datetime import datetime
+
+from bson.objectid import ObjectId
+from flask import jsonify, make_response, request
+
+from application_service import calculate_service, reply_service
+from domain_model.entities.user_hanchan import UserHanchanResult
+from domain_service import group_setting_service, hanchan_service
+from mongo_client import audit_logs_collection
+from repositories import (
+    hanchan_repository,
+    match_repository,
+    user_hanchan_repository,
+)
+
+from . import api_blueprint
+from ._auth import assert_group_member, require_web_user
+
+
+def _recalc_sum_scores(match_id):
+    hanchans = hanchan_repository.find({
+        "match_id": match_id,
+        "converted_scores": {"$ne": {}},
+    })
+    sum_scores = {}
+    for h in hanchans:
+        for uid, score in h.converted_scores.items():
+            sum_scores[uid] = sum_scores.get(uid, 0) + score
+    return sum_scores
+
+
+def _write_audit_log(operator_id, action, target_id, before, after):
+    audit_logs_collection.insert_one({
+        "operator_line_user_id": operator_id,
+        "action": action,
+        "target_id": str(target_id),
+        "before": before,
+        "after": after,
+        "created_at": datetime.now(),
+    })
+
+
+@api_blueprint.route("/hanchans/<hanchan_id>", methods=["DELETE"])
+@require_web_user
+def delete_hanchan(web_user, hanchan_id):
+    try:
+        hanchans = hanchan_repository.find({"_id": ObjectId(hanchan_id)})
+    except Exception:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    if not hanchans:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    hanchan = hanchans[0]
+
+    err = assert_group_member(web_user, hanchan.line_group_id)
+    if err:
+        return err
+
+    hanchan_repository.update({"_id": hanchan._id}, {"is_deleted": True})
+    user_hanchan_repository.delete({"hanchan_id": hanchan._id})
+
+    matches = match_repository.find({"_id": hanchan.match_id})
+    if matches:
+        sum_scores = _recalc_sum_scores(hanchan.match_id)
+        match_repository.update({"_id": hanchan.match_id}, {"sum_scores": sum_scores})
+        reply_service.push_a_message(
+            to=hanchan.line_group_id,
+            message="[Web] 半荘データが削除されました。",
+        )
+
+    _write_audit_log(
+        web_user.linked_line_user_id,
+        "delete_hanchan",
+        hanchan._id,
+        {"is_deleted": False},
+        {"is_deleted": True},
+    )
+    return jsonify({"ok": True})
+
+
+@api_blueprint.route("/hanchans/<hanchan_id>/scores", methods=["PUT"])
+@require_web_user
+def update_hanchan_scores(web_user, hanchan_id):
+    try:
+        hanchans = hanchan_repository.find({"_id": ObjectId(hanchan_id)})
+    except Exception:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    if not hanchans:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    hanchan = hanchans[0]
+
+    err = assert_group_member(web_user, hanchan.line_group_id)
+    if err:
+        return err
+
+    body = request.get_json(silent=True) or {}
+    try:
+        new_raw_scores = {k: int(v) for k, v in body.get("raw_scores", {}).items()}
+    except (ValueError, TypeError):
+        return make_response(jsonify({"error": "素点は整数で指定してください"}), 400)
+
+    if len(new_raw_scores) != 4:
+        return make_response(jsonify({"error": "4人分の素点が必要です"}), 400)
+    total = sum(new_raw_scores.values())
+    if not (100000 <= total <= 100099):
+        return make_response(jsonify({"error": f"素点の合計が不正です: {total}"}), 400)
+    if len(set(new_raw_scores.values())) != 4:
+        return make_response(jsonify({"error": "同点は許可されていません"}), 400)
+
+    setting = group_setting_service.find_or_create(hanchan.line_group_id)
+    tobashita_id = None
+    if any(v < 0 for v in new_raw_scores.values()):
+        tobashita_id = max(
+            (uid for uid, v in new_raw_scores.items() if v > 0),
+            key=lambda uid: new_raw_scores[uid],
+            default=None,
+        )
+    new_converted = calculate_service.run(
+        points=new_raw_scores,
+        ranking_prize=setting.ranking_prize,
+        tobi_prize=setting.tobi_prize,
+        rounding_method=setting.rounding_method,
+        tobashita_player_id=tobashita_id,
+    )
+
+    sorted_items = sorted(new_raw_scores.items(), key=lambda x: x[1], reverse=True)
+    new_results = [
+        UserHanchanResult(line_user_id=uid, point=score, rank=i + 1)
+        for i, (uid, score) in enumerate(sorted_items)
+    ]
+
+    before = {
+        "raw_scores": hanchan.raw_scores,
+        "converted_scores": hanchan.converted_scores,
+    }
+    hanchan_repository.update({"_id": hanchan._id}, {
+        "raw_scores": new_raw_scores,
+        "converted_scores": new_converted,
+        "results": new_results,
+    })
+
+    for r in new_results:
+        existing_uhs = user_hanchan_repository.find({
+            "hanchan_id": hanchan._id,
+            "line_user_id": r.line_user_id,
+        })
+        if existing_uhs:
+            user_hanchan_repository.update(
+                {"_id": existing_uhs[0]._id},
+                {"point": new_converted[r.line_user_id], "rank": r.rank},
+            )
+
+    sum_scores = _recalc_sum_scores(hanchan.match_id)
+    match_repository.update({"_id": hanchan.match_id}, {"sum_scores": sum_scores})
+
+    reply_service.push_a_message(
+        to=hanchan.line_group_id,
+        message="[Web] 半荘データが修正されました。",
+    )
+    _write_audit_log(
+        web_user.linked_line_user_id,
+        "update_hanchan_scores",
+        hanchan._id,
+        before,
+        {"raw_scores": new_raw_scores, "converted_scores": new_converted},
+    )
+    return jsonify({"ok": True})
+
+
+@api_blueprint.route("/matches/<match_id>", methods=["DELETE"])
+@require_web_user
+def delete_match(web_user, match_id):
+    try:
+        matches = match_repository.find({"_id": ObjectId(match_id)})
+    except Exception:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    if not matches:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    match = matches[0]
+
+    err = assert_group_member(web_user, match.line_group_id)
+    if err:
+        return err
+
+    match_repository.update({"_id": match._id}, {"is_deleted": True})
+    hanchan_service.disable_by_match_id(match._id)
+
+    reply_service.push_a_message(
+        to=match.line_group_id,
+        message="[Web] 対戦データが削除されました。",
+    )
+    _write_audit_log(
+        web_user.linked_line_user_id,
+        "delete_match",
+        match._id,
+        {"is_deleted": False},
+        {"is_deleted": True},
+    )
+    return jsonify({"ok": True})
+
+
+@api_blueprint.route("/matches/<match_id>/chips", methods=["PUT"])
+@require_web_user
+def update_match_chips(web_user, match_id):
+    try:
+        matches = match_repository.find({"_id": ObjectId(match_id)})
+    except Exception:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    if not matches:
+        return make_response(jsonify({"error": "Not found"}), 404)
+    match = matches[0]
+
+    err = assert_group_member(web_user, match.line_group_id)
+    if err:
+        return err
+
+    body = request.get_json(silent=True) or {}
+    try:
+        new_chip_scores = {k: int(v) for k, v in body.get("chip_scores", {}).items()}
+    except (ValueError, TypeError):
+        return make_response(jsonify({"error": "チップ数は整数で指定してください"}), 400)
+
+    before = {"chip_scores": match.chip_scores}
+    match_repository.update({"_id": match._id}, {"chip_scores": new_chip_scores})
+
+    reply_service.push_a_message(
+        to=match.line_group_id,
+        message="[Web] チップデータが修正されました。",
+    )
+    _write_audit_log(
+        web_user.linked_line_user_id,
+        "update_chips",
+        match._id,
+        before,
+        {"chip_scores": new_chip_scores},
+    )
+    return jsonify({"ok": True})

--- a/src/apis/api/edits.py
+++ b/src/apis/api/edits.py
@@ -6,6 +6,7 @@ from flask import jsonify, make_response, request
 from application_service import calculate_service, reply_service
 from domain_model.entities.user_hanchan import UserHanchanResult
 from domain_service import group_setting_service, hanchan_service
+from extensions import limiter
 from mongo_client import audit_logs_collection
 from repositories import (
     hanchan_repository,
@@ -41,6 +42,7 @@ def _write_audit_log(operator_id, action, target_id, before, after):
 
 
 @api_blueprint.route("/hanchans/<hanchan_id>", methods=["DELETE"])
+@limiter.limit("30/minute")
 @require_web_user
 def delete_hanchan(web_user, hanchan_id):
     try:
@@ -78,6 +80,7 @@ def delete_hanchan(web_user, hanchan_id):
 
 
 @api_blueprint.route("/hanchans/<hanchan_id>/scores", methods=["PUT"])
+@limiter.limit("30/minute")
 @require_web_user
 def update_hanchan_scores(web_user, hanchan_id):
     try:
@@ -167,6 +170,7 @@ def update_hanchan_scores(web_user, hanchan_id):
 
 
 @api_blueprint.route("/matches/<match_id>", methods=["DELETE"])
+@limiter.limit("30/minute")
 @require_web_user
 def delete_match(web_user, match_id):
     try:
@@ -199,6 +203,7 @@ def delete_match(web_user, match_id):
 
 
 @api_blueprint.route("/matches/<match_id>/chips", methods=["PUT"])
+@limiter.limit("30/minute")
 @require_web_user
 def update_match_chips(web_user, match_id):
     try:

--- a/src/apis/api/matches.py
+++ b/src/apis/api/matches.py
@@ -109,5 +109,6 @@ def get_match(web_user, match_id):
         "date": m.created_at.isoformat(),
         "hanchan_count": len(hanchans),
         "is_deleted": m.is_deleted,
+        "chip_scores": m.chip_scores or {},
         "hanchans": hanchan_list,
     })

--- a/src/mongo_client.py
+++ b/src/mongo_client.py
@@ -31,5 +31,6 @@ user_matches_collection = mongo_client[db_name].user_matches
 user_hanchans_collection = mongo_client[db_name].user_hanchans
 yakuman_users_collection = mongo_client[db_name].yakuman_users
 history_sessions_collection = mongo_client[db_name].history_sessions
+audit_logs_collection = mongo_client[db_name].audit_logs
 
 logger.info("Connected to DB server.")

--- a/src/server.py
+++ b/src/server.py
@@ -61,7 +61,7 @@ from oauth_client import oauth
 
 oauth.init_app(app)
 
-from extensions import limiter  # noqa: E402
+from extensions import limiter
 
 limiter.init_app(app)
 

--- a/tests/apis/test_api_v1_edits.py
+++ b/tests/apis/test_api_v1_edits.py
@@ -1,0 +1,223 @@
+"""API レイヤーテスト: /api/v1/hanchans, /api/v1/matches (編集系エンドポイント)
+
+Web UI からの素点・チップ修正、半荘・対戦削除のテスト。
+"""
+from domain_model.entities.group import Group
+from domain_model.entities.hanchan import Hanchan
+from domain_model.entities.match import Match
+from domain_model.entities.user_group import UserGroup
+from domain_model.entities.user_hanchan import UserHanchan
+from messaging_api_setting import line_bot_api
+from mongo_client import audit_logs_collection
+from repositories import (
+    group_repository,
+    hanchan_repository,
+    match_repository,
+    user_group_repository,
+    user_hanchan_repository,
+)
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_group_and_membership(line_group_id, line_user_id):
+    group_repository.create(Group(line_group_id=line_group_id))
+    user_group_repository.create(
+        UserGroup(line_user_id=line_user_id, line_group_id=line_group_id),
+    )
+
+
+VALID_SCORES = {"U1": 40000, "U2": 30000, "U3": 20000, "U4": 10000}
+
+
+def _make_match_with_hanchan(line_group_id, raw_scores=None):
+    raw_scores = raw_scores or VALID_SCORES
+    match = match_repository.create(Match(line_group_id=line_group_id))
+    hanchan = hanchan_repository.create(
+        Hanchan(line_group_id=line_group_id, match_id=match._id, raw_scores=raw_scores),
+    )
+    for i, (uid, score) in enumerate(
+        sorted(raw_scores.items(), key=lambda x: x[1], reverse=True),
+    ):
+        user_hanchan_repository.create(
+            UserHanchan(line_user_id=uid, hanchan_id=hanchan._id, point=score, rank=i + 1),
+        )
+    return match, hanchan
+
+
+# ─── DELETE /api/v1/hanchans/<id> ──────────────────────────────
+
+def test_delete_hanchan_without_token_returns_401(client):
+    resp = client.delete("/api/v1/hanchans/000000000000000000000000")
+    assert resp.status_code == 401
+
+
+def test_delete_hanchan_returns_404_for_invalid_id(jwt_authenticated_client):
+    client, token, _web_user, _line_user = jwt_authenticated_client
+    resp = client.delete("/api/v1/hanchans/not-an-object-id", headers=_auth(token))
+    assert resp.status_code == 404
+
+
+def test_delete_hanchan_returns_403_when_not_member(jwt_authenticated_client, mocker):
+    mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, _line_user = jwt_authenticated_client
+    line_group_id = "G_edits_delete_hanchan_403_0001"
+    group_repository.create(Group(line_group_id=line_group_id))
+    _match, hanchan = _make_match_with_hanchan(line_group_id)
+    # メンバー登録はしない
+
+    resp = client.delete(f"/api/v1/hanchans/{hanchan._id}", headers=_auth(token))
+    assert resp.status_code == 403
+
+
+def test_delete_hanchan_marks_deleted_and_recalculates_sum(jwt_authenticated_client, mocker):
+    mock_push = mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, line_user = jwt_authenticated_client
+    line_group_id = "G_edits_delete_hanchan_ok_0001"
+    _make_group_and_membership(line_group_id, line_user.line_user_id)
+    match, hanchan = _make_match_with_hanchan(line_group_id)
+
+    resp = client.delete(f"/api/v1/hanchans/{hanchan._id}", headers=_auth(token))
+    assert resp.status_code == 200
+
+    updated_hanchan = hanchan_repository.find({"_id": hanchan._id})
+    assert updated_hanchan == []  # is_deleted な半荘はデフォルトの find で除外される
+
+    remaining_user_hanchans = user_hanchan_repository.find({"hanchan_id": hanchan._id})
+    assert remaining_user_hanchans == []
+
+    updated_match = match_repository.find({"_id": match._id})[0]
+    assert updated_match.sum_scores == {}
+
+    assert mock_push.call_count == 1
+    assert audit_logs_collection.count_documents({"action": "delete_hanchan"}) == 1
+
+
+# ─── PUT /api/v1/hanchans/<id>/scores ──────────────────────────
+
+def test_update_scores_without_token_returns_401(client):
+    resp = client.put("/api/v1/hanchans/000000000000000000000000/scores", json={})
+    assert resp.status_code == 401
+
+
+def test_update_scores_returns_400_when_total_is_invalid(jwt_authenticated_client, mocker):
+    mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, line_user = jwt_authenticated_client
+    line_group_id = "G_edits_update_scores_bad_total_01"
+    _make_group_and_membership(line_group_id, line_user.line_user_id)
+    _match, hanchan = _make_match_with_hanchan(line_group_id)
+
+    bad_scores = {"U1": 40000, "U2": 30000, "U3": 20000, "U4": 5000}  # 合計95000
+    resp = client.put(
+        f"/api/v1/hanchans/{hanchan._id}/scores",
+        json={"raw_scores": bad_scores},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 400
+
+
+def test_update_scores_returns_400_when_tied(jwt_authenticated_client, mocker):
+    mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, line_user = jwt_authenticated_client
+    line_group_id = "G_edits_update_scores_tied_0001"
+    _make_group_and_membership(line_group_id, line_user.line_user_id)
+    _match, hanchan = _make_match_with_hanchan(line_group_id)
+
+    tied_scores = {"U1": 25000, "U2": 25000, "U3": 25000, "U4": 25000}
+    resp = client.put(
+        f"/api/v1/hanchans/{hanchan._id}/scores",
+        json={"raw_scores": tied_scores},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 400
+
+
+def test_update_scores_updates_hanchan_and_match_sum(jwt_authenticated_client, mocker):
+    mock_push = mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, line_user = jwt_authenticated_client
+    line_group_id = "G_edits_update_scores_ok_00001"
+    _make_group_and_membership(line_group_id, line_user.line_user_id)
+    match, hanchan = _make_match_with_hanchan(line_group_id)
+
+    new_scores = {"U1": 50000, "U2": 30000, "U3": 15000, "U4": 5000}
+    resp = client.put(
+        f"/api/v1/hanchans/{hanchan._id}/scores",
+        json={"raw_scores": new_scores},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200
+
+    updated_hanchan = hanchan_repository.find({"_id": hanchan._id})[0]
+    assert updated_hanchan.raw_scores == new_scores
+
+    updated_match = match_repository.find({"_id": match._id})[0]
+    assert updated_match.sum_scores == updated_hanchan.converted_scores
+
+    assert mock_push.call_count == 1
+    assert audit_logs_collection.count_documents({"action": "update_hanchan_scores"}) == 1
+
+
+# ─── DELETE /api/v1/matches/<id> ───────────────────────────────
+
+def test_delete_match_returns_404_for_invalid_id(jwt_authenticated_client):
+    client, token, _web_user, _line_user = jwt_authenticated_client
+    resp = client.delete("/api/v1/matches/not-an-object-id", headers=_auth(token))
+    assert resp.status_code == 404
+
+
+def test_delete_match_marks_match_and_hanchans_deleted(jwt_authenticated_client, mocker):
+    mock_push = mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, line_user = jwt_authenticated_client
+    line_group_id = "G_edits_delete_match_ok_000001"
+    _make_group_and_membership(line_group_id, line_user.line_user_id)
+    match, hanchan = _make_match_with_hanchan(line_group_id)
+
+    resp = client.delete(f"/api/v1/matches/{match._id}", headers=_auth(token))
+    assert resp.status_code == 200
+
+    assert match_repository.find({"_id": match._id}) == []
+    assert hanchan_repository.find({"_id": hanchan._id}) == []
+
+    assert mock_push.call_count == 1
+    assert audit_logs_collection.count_documents({"action": "delete_match"}) == 1
+
+
+# ─── PUT /api/v1/matches/<id>/chips ────────────────────────────
+
+def test_update_chips_returns_403_when_not_member(jwt_authenticated_client, mocker):
+    mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, _line_user = jwt_authenticated_client
+    line_group_id = "G_edits_update_chips_403_00001"
+    match = match_repository.create(Match(line_group_id=line_group_id))
+    # メンバー登録はしない
+
+    resp = client.put(
+        f"/api/v1/matches/{match._id}/chips",
+        json={"chip_scores": {"U1": 5}},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 403
+
+
+def test_update_chips_updates_match(jwt_authenticated_client, mocker):
+    mock_push = mocker.patch.object(line_bot_api, "push_message", return_value=None)
+    client, token, _web_user, line_user = jwt_authenticated_client
+    line_group_id = "G_edits_update_chips_ok_000001"
+    _make_group_and_membership(line_group_id, line_user.line_user_id)
+    match = match_repository.create(Match(line_group_id=line_group_id))
+
+    new_chips = {"U1": 5, "U2": -5}
+    resp = client.put(
+        f"/api/v1/matches/{match._id}/chips",
+        json={"chip_scores": new_chips},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200
+
+    updated_match = match_repository.find({"_id": match._id})[0]
+    assert updated_match.chip_scores == new_chips
+
+    assert mock_push.call_count == 1
+    assert audit_logs_collection.count_documents({"action": "update_chips"}) == 1


### PR DESCRIPTION
## Summary
- Group members can now correct raw scores, adjust chip counts, and delete a hanchan or match from the match detail page in the Web UI (`frontend/src/pages/MatchDetailPage.tsx`).
- New backend endpoints in `src/apis/api/edits.py`: `DELETE /hanchans/<id>`, `PUT /hanchans/<id>/scores`, `DELETE /matches/<id>`, `PUT /matches/<id>/chips`. All require JWT auth + group membership (`require_web_user` + `assert_group_member`).
- Score updates validate the raw score total (100000–100099) and reject duplicate ranks.
- Every edit is recorded to a new `audit_logs` collection (operator LINE user ID, action, before/after values, timestamp) and pushes a LINE message to the group ("[Web] ... 修正/削除されました").
- Added `tests/apis/test_api_v1_edits.py` (12 tests) covering auth (401), membership (403), not-found (404), validation errors (400), successful edits, and audit log writes.

Part of FEZ-30 (Linear), split into 5 focused PRs; this is PR 2 of 5.

## Test plan
- [x] `pytest` — full suite: 668 passed, 7 skipped (ran via `docker exec flask_test pytest`, matching CI's Python 3.11 + MongoDB setup)
- [x] `ruff check .` — all checks passed
- [x] `npm run build` (tsc --noEmit + vite build) passes
- [x] `npm run lint` — no new errors (1 pre-existing unrelated error in `useAuth.ts`, confirmed present on `main` without this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)