### PR TITLE
feat: enable rate limiting (was default_limits=[])

### DIFF
--- a/src/apis/auth.py
+++ b/src/apis/auth.py
@@ -14,6 +14,7 @@ from flask_jwt_extended import create_access_token
 from linebot.v3.webhook import WebhookHandler
 
 import env_var
+from extensions import limiter
 from oauth_client import oauth
 from repositories import user_repository, web_user_repository
 
@@ -22,8 +23,9 @@ auth_blueprint = Blueprint("auth_blueprint", __name__, url_prefix="/auth")
 
 
 @auth_blueprint.route("/login", methods=["POST"])
+@limiter.limit("10/minute")
 def api_login():
-    # 本番環境ではパスワード認証なし /auth/login を無効化（Google OAuth のみ使用）
+    # 本番環境ではパスワード認証なし /auth/login を無効化（LINE Login のみ使用）
     if env_var.FLASK_ENV == "production":
         abort(404)
     body = request.get_json(silent=True) or {}
@@ -45,6 +47,7 @@ def authenticate(line_user_id: str) -> str:
 
 
 @auth_blueprint.route("/line/login")
+@limiter.limit("10/minute")
 def line_login():
     line = oauth.create_client("line")
     redirect_uri = url_for("auth_blueprint.line_authorize", _external=True)
@@ -52,6 +55,7 @@ def line_login():
 
 
 @auth_blueprint.route("/line/authorize")
+@limiter.limit("10/minute")
 def line_authorize():
     line = oauth.create_client("line")
     token = line.authorize_access_token()

--- a/src/extensions.py
+++ b/src/extensions.py
@@ -1,8 +1,11 @@
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 
+# storage_uri="memory://" はインスタンス単位のカウンタで、Cloud Run の複数インスタンス間では
+# 共有されない（実効上限はインスタンス数倍になりうる）。現状の利用規模では Redis 等への
+# 切替は過剰投資と判断し、単一インスタンス前提の制限として運用する。
 limiter = Limiter(
     get_remote_address,
-    default_limits=[],
+    default_limits=["200/minute"],
     storage_uri="memory://",
 )


### PR DESCRIPTION
## Summary
- `src/extensions.py`: flask-limiter was wired into the app but `default_limits=[]` made it a no-op everywhere except `/callback` (300/min). Set a `200/minute` app-wide default.
- `src/apis/auth.py`: added a stricter `10/minute` limit on the login-related endpoints (`/auth/login` dev-only login, `/auth/line/login`, `/auth/line/authorize`).
- Fixed a stale code comment that said "Google OAuth" on the `/auth/login` production guard — actual auth is LINE Login only.
- Noted in a comment that `storage_uri="memory://"` is per-instance and not shared across Cloud Run instances; kept as-is given current usage scale (see `pico/projects/mahjong-manager-bot.md`), Redis would be over-engineering right now.

Part of FEZ-30 (Linear), split into 5 focused PRs; this is PR 3 of 5. (Rate limits for the new edit endpoints in PR #248 will be added there directly, since that PR is what introduces them.)

## Test plan
- [x] `pytest` — full suite passes (656 passed, 7 skipped) via `docker exec flask_test pytest`, matching CI's Python 3.11 + MongoDB setup
- [x] `ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
