### PR TITLE
fix: stop passing JWT via URL query after LINE login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
 import { AppLayout } from '@/components/layout/AppLayout'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { LoginPage } from '@/pages/LoginPage'
@@ -14,6 +16,8 @@ import { PlayerPage } from '@/pages/PlayerPage'
 import { SettingsPage } from '@/pages/SettingsPage'
 import { PrivacyPolicyPage } from '@/pages/PrivacyPolicyPage'
 import { TermsOfServicePage } from '@/pages/TermsOfServicePage'
+import { setToken } from '@/lib/auth'
+import api from '@/lib/api'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,6 +29,32 @@ const queryClient = new QueryClient({
 })
 
 function App() {
+  // LINE Login コールバック直後、一度だけ httpOnly Cookie に橋渡しされた JWT を
+  // 受け取る。ProtectedRoute の認証判定より先に完了させる必要があるため、
+  // Routes のレンダリングをこの処理の完了までブロックする。
+  const [bootstrapped, setBootstrapped] = useState(false)
+
+  useEffect(() => {
+    api.get<{ access_token: string }>('/auth/exchange')
+      .then((res) => {
+        if (res.status === 200 && res.data.access_token) {
+          setToken(res.data.access_token)
+        }
+      })
+      .catch(() => {
+        // ネットワークエラー等: 未認証のまま続行
+      })
+      .finally(() => setBootstrapped(true))
+  }, [])
+
+  if (!bootstrapped) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <Loader2 className="animate-spin text-muted-foreground" size={24} />
+      </div>
+    )
+  }
+
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
-import { isAuthenticated, removeToken, setToken } from '@/lib/auth'
+import { useNavigate } from 'react-router-dom'
+import { isAuthenticated, removeToken } from '@/lib/auth'
 import api from '@/lib/api'
 import type { WebUser } from '@/types'
 
@@ -8,17 +8,8 @@ export function useAuth() {
   const [user, setUser] = useState<WebUser | null>(null)
   const [loading, setLoading] = useState(true)
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
 
   useEffect(() => {
-    // OAuth コールバック後の token 受け取り
-    const token = searchParams.get('token')
-    if (token) {
-      setToken(token)
-      navigate('/', { replace: true })
-      return
-    }
-
     if (!isAuthenticated()) {
       setLoading(false)
       return
@@ -30,7 +21,7 @@ export function useAuth() {
         removeToken()
       })
       .finally(() => setLoading(false))
-  }, [navigate, searchParams])
+  }, [])
 
   const logout = () => {
     removeToken()
@@ -39,18 +30,4 @@ export function useAuth() {
   }
 
   return { user, loading, isAuthenticated: isAuthenticated(), logout }
-}
-
-export function useTokenFromUrl() {
-  const [searchParams, setSearchParams] = useSearchParams()
-
-  useEffect(() => {
-    const token = searchParams.get('token')
-    if (token) {
-      setToken(token)
-      const newParams = new URLSearchParams(searchParams)
-      newParams.delete('token')
-      setSearchParams(newParams, { replace: true })
-    }
-  }, [searchParams, setSearchParams])
 }

--- a/src/apis/api/__init__.py
+++ b/src/apis/api/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 api_blueprint = Blueprint("api_blueprint", __name__, url_prefix="/api/v1")
 
-from . import edits, groups, matches, rankings, users  # noqa: F401
+from . import auth, edits, groups, matches, rankings, users  # noqa: F401

--- a/src/apis/api/auth.py
+++ b/src/apis/api/auth.py
@@ -1,0 +1,28 @@
+from flask import jsonify, make_response, request
+
+import env_var
+
+from . import api_blueprint
+
+
+@api_blueprint.route("/auth/exchange", methods=["GET"])
+def exchange_pending_token():
+    """LINE Login コールバック直後に一度だけ Cookie へ橋渡しした JWT を SPA へ渡す。
+
+    `src/apis/auth.py` の `line_authorize` がセットする短命 Cookie (`pending_token`)
+    を読み取り、JSON で返却しつつ即座に失効させる。Cookie が無ければ 204。
+    """
+    pending_token = request.cookies.get("pending_token")
+    if not pending_token:
+        return make_response("", 204)
+
+    response = make_response(jsonify({"access_token": pending_token}), 200)
+    response.set_cookie(
+        "pending_token",
+        "",
+        max_age=0,
+        httponly=True,
+        secure=env_var.FLASK_ENV == "production",
+        samesite="Lax",
+    )
+    return response

--- a/src/apis/auth.py
+++ b/src/apis/auth.py
@@ -89,9 +89,19 @@ def line_authorize():
     session["access_token"] = token["access_token"]
     session["login_user_id"] = web_user._id
 
-    # JWT を発行してフロントエンドへ渡す
+    # JWT を発行してフロントエンドへ渡す。ブラウザ履歴・Referrer・アクセスログへの
+    # 平文JWT漏洩を避けるため、URLクエリではなく短命(60秒)のhttpOnly Cookieで
+    # 一度だけ橋渡しする。SPA は起動時に GET /api/v1/auth/exchange でこの
+    # Cookie を読み取り、以後は通常どおり Authorization ヘッダーで認証する。
     jwt_token = create_access_token(identity=str(web_user._id))
     redirect_to = session.pop("next_page_url", "/")
-    # React SPA にトークンをクエリパラメータで渡す
-    separator = "&" if "?" in redirect_to else "?"
-    return redirect(f"{redirect_to}{separator}token={jwt_token}")
+    response = make_response(redirect(redirect_to))
+    response.set_cookie(
+        "pending_token",
+        jwt_token,
+        max_age=60,
+        httponly=True,
+        secure=env_var.FLASK_ENV == "production",
+        samesite="Lax",
+    )
+    return response

--- a/tests/apis/test_api_v1_auth_exchange.py
+++ b/tests/apis/test_api_v1_auth_exchange.py
@@ -1,0 +1,47 @@
+"""API レイヤーテスト: GET /api/v1/auth/exchange
+
+LINE Login コールバック直後に一度だけ Cookie へ橋渡しした JWT を SPA へ渡すエンドポイント。
+"""
+from flask_jwt_extended import create_access_token
+
+import server as srv
+from domain_model.entities.web_user import WebUser
+from repositories import web_user_repository
+
+
+def test_exchange_without_cookie_returns_204(client):
+    resp = client.get("/api/v1/auth/exchange")
+    assert resp.status_code == 204
+
+
+def test_exchange_with_cookie_returns_token_and_clears_cookie(client):
+    web_user = web_user_repository.create(
+        WebUser(user_code="exchange@example.com", name="Exchange User"),
+    )
+    with srv.app.app_context():
+        token = create_access_token(identity=str(web_user._id))
+
+    client.set_cookie("pending_token", token)
+    resp = client.get("/api/v1/auth/exchange")
+
+    assert resp.status_code == 200
+    assert resp.get_json()["access_token"] == token
+
+    set_cookie_header = resp.headers.get("Set-Cookie", "")
+    assert "pending_token=" in set_cookie_header
+    assert "Max-Age=0" in set_cookie_header
+
+
+def test_exchange_cannot_be_reused(client):
+    web_user = web_user_repository.create(
+        WebUser(user_code="exchange2@example.com", name="Exchange User 2"),
+    )
+    with srv.app.app_context():
+        token = create_access_token(identity=str(web_user._id))
+
+    client.set_cookie("pending_token", token)
+    first = client.get("/api/v1/auth/exchange")
+    assert first.status_code == 200
+
+    second = client.get("/api/v1/auth/exchange")
+    assert second.status_code == 204


### PR DESCRIPTION
## Summary
- `line_authorize` (`src/apis/auth.py`) previously redirected the SPA back with the freshly-issued JWT in a `?token=` URL query param. That's a leak surface: browser history, `Referer` headers on subsequent same-origin requests/links, and server access logs can all end up holding a live JWT.
- It now sets the token in a short-lived (60s), `httpOnly` + `SameSite=Lax` cookie (`secure` in production) and redirects with a clean URL instead.
- New `GET /api/v1/auth/exchange` (`src/apis/api/auth.py`) reads that cookie once, returns `{"access_token": ...}`, and immediately expires the cookie (`Max-Age=0`) so it can't be replayed.
- Frontend (`App.tsx`) calls `/auth/exchange` once during app bootstrap, before `<Routes>` renders — this matters because `ProtectedRoute` checks auth synchronously on first render, so the exchange has to resolve before routing happens. Token is stored the same way as before (`localStorage`, sent as a `Bearer` header) — this PR only changes how the token crosses from the OAuth redirect into the SPA, not the ongoing auth mechanism.
- Removed the now-dead `useTokenFromUrl` export and the URL-token-reading branch in `useAuth.ts` (superseded by the exchange call).

This is a deliberately narrow fix (per user decision on FEZ-30): only the URL-exposure issue is addressed, Bearer-header + localStorage auth is unchanged.

Part of FEZ-30 (Linear), split into 5 focused PRs; this is PR 4 of 5.

## Test plan
- [x] New `tests/apis/test_api_v1_auth_exchange.py`: no cookie → 204; cookie present → 200 + token + cookie cleared; cookie can't be reused (second call → 204)
- [x] `pytest` — full suite passes (659 passed, 7 skipped) via `docker exec flask_test pytest`, matching CI's Python 3.11 + MongoDB setup
- [x] `ruff check .` — all checks passed
- [x] `npm run build` (tsc --noEmit + vite build) passes
- [x] `npm run lint` — no new errors (1 pre-existing unrelated error in `useAuth.ts`, confirmed present on `main` without this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)